### PR TITLE
[#11] feat: Integrar creacion de año con api backend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { UserProvider } from "./user/contexts/UserProvider";
+import { YearProvider } from "./admin/contexts/YearProvider";
 import { useAuth } from "./user/hooks/useAuth";
 import Login from "./user/pages/Login/LoginPage";
 import AdminDashboard from "./admin/pages/Dashboard/AdminDashboardPage";
@@ -52,15 +53,17 @@ const AppContent: React.FC = () => {
             path="/dashboard/*"
             element={
               isAuthenticated ? (
-                <motion.div
-                  key="dashboard"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.3 }}
-                >
-                  <AdminDashboard />
-                </motion.div>
+                <YearProvider>
+                  <motion.div
+                    key="dashboard"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    <AdminDashboard />
+                  </motion.div>
+                </YearProvider>
               ) : (
                 <Navigate to="/login" replace />
               )

--- a/src/admin/contexts/YearContext.ts
+++ b/src/admin/contexts/YearContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import type { YearContextType } from "./YearContext.types";
+
+export const YearContext = createContext<YearContextType | undefined>(
+  undefined
+);

--- a/src/admin/contexts/YearContext.types.ts
+++ b/src/admin/contexts/YearContext.types.ts
@@ -1,0 +1,6 @@
+import type { CreateYearPayload } from "../services/Year/YearService";
+
+export interface YearContextType {
+  loading: boolean;
+  registerYear: (data: CreateYearPayload) => Promise<void>;
+}

--- a/src/admin/contexts/YearProvider.tsx
+++ b/src/admin/contexts/YearProvider.tsx
@@ -1,4 +1,3 @@
-// YearProvider.tsx
 import { useState, type ReactNode } from "react";
 import { YearContext } from "./YearContext";
 import type { YearContextType } from "./YearContext.types";

--- a/src/admin/contexts/YearProvider.tsx
+++ b/src/admin/contexts/YearProvider.tsx
@@ -1,0 +1,35 @@
+// YearProvider.tsx
+import { useState, type ReactNode } from "react";
+import { YearContext } from "./YearContext";
+import type { YearContextType } from "./YearContext.types";
+import { YearService } from "../services/Year/YearService";
+import type { CreateYearPayload } from "../services/Year/YearService";
+
+interface YearProviderProps {
+  children: ReactNode;
+}
+
+export const YearProvider: React.FC<YearProviderProps> = ({ children }) => {
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const registerYear = async (data: CreateYearPayload): Promise<void> => {
+    setLoading(true);
+    try {
+      await YearService.registerYearApi(data);
+    } catch (error) {
+      console.error("Error al crear el año:", error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const contextValue: YearContextType = {
+    loading,
+    registerYear,
+  };
+
+  return (
+    <YearContext.Provider value={contextValue}>{children}</YearContext.Provider>
+  );
+};

--- a/src/admin/hooks/useYear.ts
+++ b/src/admin/hooks/useYear.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { YearContext } from "../contexts/YearContext";
+
+export const useYear = () => {
+  const context = useContext(YearContext);
+  if (!context) {
+    throw new Error("useYear must be used within an YearProvider");
+  }
+  return context;
+};

--- a/src/admin/services/Year/YearService.ts
+++ b/src/admin/services/Year/YearService.ts
@@ -1,0 +1,19 @@
+// YearService.ts
+import api from "../../../shared/utils/api";
+
+export interface CreateYearPayload {
+  name: string;
+}
+
+const registerYearApi = async (data: CreateYearPayload): Promise<void> => {
+  try {
+    await api.post("/admin/years", data);
+  } catch (error) {
+    console.error("Error al crear el año:", error);
+    throw error;
+  }
+};
+
+export const YearService = {
+  registerYearApi,
+};

--- a/src/admin/services/Year/YearService.ts
+++ b/src/admin/services/Year/YearService.ts
@@ -1,5 +1,5 @@
-// YearService.ts
 import api from "../../../shared/utils/api";
+import { urls } from "../../urls";
 
 export interface CreateYearPayload {
   name: string;
@@ -7,7 +7,7 @@ export interface CreateYearPayload {
 
 const registerYearApi = async (data: CreateYearPayload): Promise<void> => {
   try {
-    await api.post("/admin/years", data);
+    await api.post(urls.Years, data);
   } catch (error) {
     console.error("Error al crear el año:", error);
     throw error;

--- a/src/admin/urls.ts
+++ b/src/admin/urls.ts
@@ -1,0 +1,3 @@
+export const urls={
+    Years: '/admin/years',
+}

--- a/src/admin/views/CreateYearView/CreateYearView.tsx
+++ b/src/admin/views/CreateYearView/CreateYearView.tsx
@@ -5,20 +5,26 @@ import { FaCalendarAlt, FaSave } from "react-icons/fa";
 import Card from "../../../shared/components/Card/CardComponent";
 import Button from "../../../shared/components/Button/ButtonComponent";
 import Input from "../../../shared/components/Input/InputComponent";
+import { useYear } from "../../hooks/useYear";
 import styles from "./CreateYearView.module.css";
 
 const CreateYearView: React.FC = () => {
-  const [formData, setFormData] = useState({
-    name: "",
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    console.log("Año creado:", formData);
-  };
+  const [formData, setFormData] = useState({ name: "" });
+  const { registerYear, loading } = useYear();
 
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await registerYear(formData);
+      alert("Año creado exitosamente.");
+      setFormData({ name: "" });
+    } catch (err) {
+      alert("Hubo un error al crear el año.");
+    }
   };
 
   return (
@@ -31,7 +37,7 @@ const CreateYearView: React.FC = () => {
       <div className={styles.header}>
         <h1 className={styles.title}>Generar Año</h1>
         <p className={styles.subtitle}>
-          Crea un nuevo año académico en el sistema
+          Crea un nuevo año en el sistema
         </p>
       </div>
 
@@ -55,11 +61,11 @@ const CreateYearView: React.FC = () => {
           </div>
 
           <div className={styles.buttonGroup}>
-            <Button type="submit" variant="primary">
+            <Button type="submit" variant="primary" disabled={loading}>
               <FaSave className={styles.buttonIcon} />
-              Crear Año
+              {loading ? "Creando..." : "Crear Año"}
             </Button>
-            <Button type="button" variant="outline">
+            <Button type="button" variant="outline" disabled={loading}>
               Cancelar
             </Button>
           </div>

--- a/src/shared/utils/api.ts
+++ b/src/shared/utils/api.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+const BASE_URL = "https://play2learn.backend.desarrollo.systemsbinary.com";
+
+const api = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;


### PR DESCRIPTION
## Descripción
Integración de la creación de un year con la API del back

## Explicación
Te explico más o menos que hice y por qué:

**api.ts:**
Como te conte ayer, hice un api.ts ue sería la instanciación de axios en el proyecto, asi no llamamos a axios en cada service. Lo que podemos cambiar de aca es la base_url y hacerlo como lo hiciste vos en login.

**YearService.ts:**
Aca hay varias cosas diferentes al login sabiendo que ya no tengo que importar axios y todo porque ya esta instanciado. Lo más importante diría es que que hago la interfaz para tipar el payload del POST.

**YearContextType.types.ts:**
En admin voy a tener varios tipados y no quiero que haya un adminTypes (que voy a terminar borrado) porque la buena practica dice que es mejor tenerlo así separadito.

Lo demás creo que no hace falta explicarlo, espero la review.

## Issue relacionada
Closes #11 