### PR TITLE
[#41] feat: Crear vista de listado de materias

### DIFF
--- a/src/admin/contexts/subjectContext/SubjectContext.type.ts
+++ b/src/admin/contexts/subjectContext/SubjectContext.type.ts
@@ -1,6 +1,18 @@
-import type { CreateSubjectPayload } from "../../services/subject/SubjectService";
+import type {
+  GetPaginated,
+  PaginatedData,
+} from "../../../shared/types/PaginacionType";
+import type {
+  CreateSubjectPayload,
+  SubjectResponseDto,
+} from "../../services/subject/SubjectService";
 
 export interface SubjectContextType {
   loading: boolean;
   registerSubject: (data: CreateSubjectPayload) => Promise<void>;
+  getSubject: () => void;
+  getPaginatedSubject: (params: GetPaginated) => Promise<void>;
+  deleteSubject: (id: number) => Promise<void>;
+  subjects: SubjectResponseDto[];
+  paginatedSubjects: PaginatedData<SubjectResponseDto> | null;
 }

--- a/src/admin/contexts/subjectContext/SubjectContext.type.ts
+++ b/src/admin/contexts/subjectContext/SubjectContext.type.ts
@@ -5,14 +5,18 @@ import type {
 import type {
   CreateSubjectPayload,
   SubjectResponseDto,
+  UpdateSubjectPayload,
 } from "../../services/subject/SubjectService";
 
 export interface SubjectContextType {
   loading: boolean;
   registerSubject: (data: CreateSubjectPayload) => Promise<void>;
+  updateSubject: (data: UpdateSubjectPayload) => Promise<void>;
   getSubject: () => void;
   getPaginatedSubject: (params: GetPaginated) => Promise<void>;
   deleteSubject: (id: number) => Promise<void>;
   subjects: SubjectResponseDto[];
   paginatedSubjects: PaginatedData<SubjectResponseDto> | null;
+  selectedSubject: SubjectResponseDto | null;
+  setSelectedSubject: (subject: SubjectResponseDto | null) => void;
 }

--- a/src/admin/contexts/subjectContext/SubjectProvider.tsx
+++ b/src/admin/contexts/subjectContext/SubjectProvider.tsx
@@ -9,6 +9,7 @@ import { SubjectService } from "../../services/subject/SubjectService";
 import type {
   CreateSubjectPayload,
   SubjectResponseDto,
+  UpdateSubjectPayload,
 } from "../../services/subject/SubjectService";
 
 interface SubjectProviderProps {
@@ -22,6 +23,8 @@ export const SubjectProvider: React.FC<SubjectProviderProps> = ({
   const [subjects, setSubjects] = useState<SubjectResponseDto[]>([]);
   const [paginatedSubjects, setPaginatedSubjects] =
     useState<PaginatedData<SubjectResponseDto> | null>(null);
+  const [selectedSubject, setSelectedSubject] =
+    useState<SubjectResponseDto | null>(null);
 
   const registerSubject = async (data: CreateSubjectPayload): Promise<void> => {
     setLoading(true);
@@ -29,6 +32,18 @@ export const SubjectProvider: React.FC<SubjectProviderProps> = ({
       await SubjectService.registerSubjectApi(data);
     } catch (error) {
       console.error("Error al crear la materia:", error); // TODO: REMOVE_DEBUG
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateSubject = async (data: UpdateSubjectPayload): Promise<void> => {
+    setLoading(true);
+    try {
+      await SubjectService.updateSubjectApi(data);
+    } catch (error) {
+      console.error("Error al actualizar la materia:", error);
       throw error;
     } finally {
       setLoading(false);
@@ -79,11 +94,14 @@ export const SubjectProvider: React.FC<SubjectProviderProps> = ({
   const contextValue: SubjectContextType = {
     loading,
     registerSubject,
+    updateSubject,
     getSubject,
     getPaginatedSubject,
     deleteSubject,
     subjects,
     paginatedSubjects,
+    selectedSubject,
+    setSelectedSubject,
   };
 
   return (

--- a/src/admin/contexts/subjectContext/SubjectProvider.tsx
+++ b/src/admin/contexts/subjectContext/SubjectProvider.tsx
@@ -1,8 +1,15 @@
-import { useState, type ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
+import type {
+  GetPaginated,
+  PaginatedData,
+} from "../../../shared/types/PaginacionType";
 import { SubjectContext } from "./SubjectContext";
 import type { SubjectContextType } from "./SubjectContext.type";
 import { SubjectService } from "../../services/subject/SubjectService";
-import type { CreateSubjectPayload } from "../../services/subject/SubjectService";
+import type {
+  CreateSubjectPayload,
+  SubjectResponseDto,
+} from "../../services/subject/SubjectService";
 
 interface SubjectProviderProps {
   children: ReactNode;
@@ -12,6 +19,9 @@ export const SubjectProvider: React.FC<SubjectProviderProps> = ({
   children,
 }) => {
   const [loading, setLoading] = useState<boolean>(false);
+  const [subjects, setSubjects] = useState<SubjectResponseDto[]>([]);
+  const [paginatedSubjects, setPaginatedSubjects] =
+    useState<PaginatedData<SubjectResponseDto> | null>(null);
 
   const registerSubject = async (data: CreateSubjectPayload): Promise<void> => {
     setLoading(true);
@@ -25,9 +35,55 @@ export const SubjectProvider: React.FC<SubjectProviderProps> = ({
     }
   };
 
+  const getSubject = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await SubjectService.getSubjectApi();
+      setSubjects(response.data.data);
+    } catch (error) {
+      console.error("Error al obtener las materias:", error); // TODO: REMOVE_DEBUG
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const getPaginatedSubject = useCallback(
+    async (params: GetPaginated): Promise<void> => {
+      setLoading(true);
+      try {
+        const response = await SubjectService.getPaginatedSubjectApi(params);
+        setPaginatedSubjects(response.data);
+      } catch (error) {
+        console.error("Error al obtener las materias paginadas:", error); // TODO: REMOVE_DEBUG
+        throw error;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const deleteSubject = async (id: number): Promise<void> => {
+    setLoading(true);
+    try {
+      await SubjectService.deleteSubjectApi(id);
+    } catch (error) {
+      console.error("Error al eliminar la materia:", error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const contextValue: SubjectContextType = {
     loading,
     registerSubject,
+    getSubject,
+    getPaginatedSubject,
+    deleteSubject,
+    subjects,
+    paginatedSubjects,
   };
 
   return (

--- a/src/admin/services/subject/SubjectService.ts
+++ b/src/admin/services/subject/SubjectService.ts
@@ -11,7 +11,15 @@ import type { TeacherResponseDto } from "../teacher/TeacherService";
 export interface CreateSubjectPayload {
   name: string;
   courseId: number;
-  teacherId: number;
+  teacherId: number | null;
+  optional: boolean;
+}
+
+export interface UpdateSubjectPayload {
+  id: number;
+  name: string;
+  courseId: number;
+  teacherId: number | null;
   optional: boolean;
 }
 
@@ -37,6 +45,16 @@ const registerSubjectApi = async (
     await api.post(urls.Subject, data);
   } catch (error) {
     console.error("Error al crear la materia:", error); // TODO: REMOVE_DEBUG
+    throw error;
+  }
+};
+
+const updateSubjectApi = async (data: UpdateSubjectPayload): Promise<void> => {
+  try {
+    const { id, ...payload } = data;
+    await api.put(`${urls.Subject}/${data.id}`, payload);
+  } catch (error) {
+    console.error("Error al actualizar la materia:", error); // TODO: REMOVE_DEBUG
     throw error;
   }
 };
@@ -80,6 +98,7 @@ const deleteSubjectApi = async (id: number): Promise<void> => {
 
 export const SubjectService = {
   registerSubjectApi,
+  updateSubjectApi,
   getSubjectApi,
   getPaginatedSubjectApi,
   deleteSubjectApi,

--- a/src/admin/services/subject/SubjectService.ts
+++ b/src/admin/services/subject/SubjectService.ts
@@ -51,8 +51,7 @@ const registerSubjectApi = async (
 
 const updateSubjectApi = async (data: UpdateSubjectPayload): Promise<void> => {
   try {
-    const { id, ...payload } = data;
-    await api.put(`${urls.Subject}/${data.id}`, payload);
+    await api.put(`${urls.Subject}/${data.id}`, data);
   } catch (error) {
     console.error("Error al actualizar la materia:", error); // TODO: REMOVE_DEBUG
     throw error;

--- a/src/admin/services/subject/SubjectService.ts
+++ b/src/admin/services/subject/SubjectService.ts
@@ -1,11 +1,33 @@
+import type {
+  GetPaginated,
+  PaginatedData,
+} from "../../../shared/types/PaginacionType";
 import api from "../../../shared/utils/api";
+import { buildCleanPaginatedParams } from "../../../shared/utils/apiUtils";
 import { urls } from "../urls";
+import type { CourseResponseDto } from "../course/CourseService";
+import type { TeacherResponseDto } from "../teacher/TeacherService";
 
 export interface CreateSubjectPayload {
   name: string;
   courseId: number;
   teacherId: number;
   optional: boolean;
+}
+
+export interface SubjectResponseDto {
+  id: number;
+  name: string;
+  course: CourseResponseDto;
+  teacher: TeacherResponseDto;
+  optional: boolean;
+}
+
+export interface PaginatedSubjectResponse {
+  data: PaginatedData<SubjectResponseDto>;
+  message: string;
+  errors: any;
+  timestamp: string;
 }
 
 const registerSubjectApi = async (
@@ -19,6 +41,46 @@ const registerSubjectApi = async (
   }
 };
 
+const getSubjectApi = async () => {
+  try {
+    const response = await api.get(urls.Subject);
+    return response;
+  } catch (error) {
+    console.error("Error al obtener las materias:", error); // TODO: REMOVE_DEBUG
+    throw error;
+  }
+};
+
+const getPaginatedSubjectApi = async (
+  params: GetPaginated
+): Promise<PaginatedSubjectResponse> => {
+  try {
+    const cleanParams = buildCleanPaginatedParams(params);
+
+    const response = await api.get(urls.SubjectPaginated, {
+      params: cleanParams,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error("Error al obtener materias paginadas:", error); // TODO: REMOVE_DEBUG
+    throw error;
+  }
+};
+
+const deleteSubjectApi = async (id: number): Promise<void> => {
+  try {
+    //console.log(`Eliminando materia con ID: ${id}`); // TODO: REMOVE_DEBUG
+    await api.delete(`${urls.Subject}/${id}`);
+  } catch (error) {
+    console.error("Error al eliminar la materia:", error); // TODO: REMOVE_DEBUG
+    throw error;
+  }
+};
+
 export const SubjectService = {
   registerSubjectApi,
+  getSubjectApi,
+  getPaginatedSubjectApi,
+  deleteSubjectApi,
 };

--- a/src/admin/services/urls.ts
+++ b/src/admin/services/urls.ts
@@ -6,4 +6,5 @@ export const urls = {
   Course: "/admin/courses",
   CoursePaginated: "/admin/courses/paginated",
   Subject: "/admin/subjects",
+  SubjectPaginated: "admin/subjects/paginated",
 };

--- a/src/admin/views/Subject/CreateSubjectView.tsx
+++ b/src/admin/views/Subject/CreateSubjectView.tsx
@@ -149,8 +149,7 @@ const CreateSubjectView: React.FC = () => {
           <div className={styles.formGrid}>
             <div className={styles.inputGroup}>
               <label className={styles.label}>Docente</label>
-              {/* Mientras se arregla el getTeacher, pongo un input */}
-              {/* <select
+              <select
                 className={styles.select}
                 value={formData.teacherId}
                 onChange={(e) =>
@@ -163,16 +162,10 @@ const CreateSubjectView: React.FC = () => {
                     {teacher.name}
                   </option>
                 ))}
-              </select> */}
-              <Input
-                placeholder="Docente"
-                value={formData.teacherId}
-                onChange={(e) => handleChange("teacherId", e.target.value)}
-                required
-              />
+              </select>
             </div>
             <div className={styles.inputGroup}>
-              <label className={styles.label}>Materia Opcional</label>
+              <label className={styles.label}>Materia Opcional *</label>
               <BooleanInput
                 checked={formData.optional}
                 onChange={(checked) => handleChange("optional", checked)}

--- a/src/admin/views/Subject/CreateSubjectView.tsx
+++ b/src/admin/views/Subject/CreateSubjectView.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { FaGraduationCap, FaSave } from "react-icons/fa";
 import BooleanInput from "../../../shared/components/BooleanInput/BooleanInputComponent";
@@ -13,10 +14,15 @@ import { useSubject } from "../../hooks/useSubject";
 import styles from "./CreateSubjectView.module.css";
 
 const CreateSubjectView: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = Boolean(id);
+
   const { getYear, years } = useYear();
   const { getCourse, courses } = useCourse();
   const { getTeacher, teachers } = useTeacher();
-  const { registerSubject, loading } = useSubject();
+  const { registerSubject, updateSubject, loading, selectedSubject } =
+    useSubject();
 
   const [formData, setFormData] = useState({
     name: "",
@@ -40,20 +46,54 @@ const CreateSubjectView: React.FC = () => {
     });
   };
 
+  useEffect(() => {
+    const loadInitialData = async () => {
+      await Promise.all([getYear(), getCourse(), getTeacher()]);
+    };
+
+    loadInitialData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (isEditMode && selectedSubject) {
+      setFormData({
+        name: selectedSubject.name || "",
+        yearId: selectedSubject.course?.year?.id || 0,
+        courseId: selectedSubject.course?.id || 0,
+        teacherId: selectedSubject.teacher?.id || 0,
+        optional: selectedSubject.optional || false,
+      });
+    }
+  }, [isEditMode, selectedSubject]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const payload = {
       name: formData.name.trim(),
       courseId: formData.courseId,
-      teacherId: formData.teacherId,
+      teacherId: formData.teacherId === 0 ? null : formData.teacherId,
       optional: formData.optional,
     };
     try {
-      await registerSubject(payload);
-      alert("Materia creada exitosamente.");
-      resetFormData();
+      if (isEditMode && id) {
+        await updateSubject({
+          id: Number(id),
+          ...payload,
+        });
+        alert("Materia actualizada exitosamente.");
+        navigate("/dashboard/subjects/list");
+      } else {
+        await registerSubject(payload);
+        alert("Materia creada exitosamente.");
+        resetFormData();
+      }
     } catch (err) {
-      alert("Hubo un error al crear la materia.");
+      alert(
+        isEditMode
+          ? "Hubo un error al actualizar la materia."
+          : "Hubo un error al crear la materia."
+      );
     }
   };
 
@@ -61,12 +101,11 @@ const CreateSubjectView: React.FC = () => {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
-  useEffect(() => {
-    getYear();
-    getCourse();
-    getTeacher();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const handleCancel = () => {
+    if (isEditMode) {
+      navigate("/dashboard/subjects/list");
+    }
+  };
 
   return (
     <motion.div
@@ -76,9 +115,13 @@ const CreateSubjectView: React.FC = () => {
       className={styles.container}
     >
       <div className={styles.header}>
-        <h1 className={styles.title}>Generar Materia</h1>
+        <h1 className={styles.title}>
+          {isEditMode ? "Modificar Materia" : "Generar Materia"}
+        </h1>
         <p className={styles.subtitle}>
-          Registra un nueva materia en el sistema
+          {isEditMode
+            ? "Modifica la información de la materia"
+            : "Registra una nueva materia en el sistema"}
         </p>
       </div>
 
@@ -125,6 +168,7 @@ const CreateSubjectView: React.FC = () => {
                 ))}
               </select>
             </div>
+
             <div className={styles.inputGroup}>
               <label className={styles.label}>Curso *</label>
               <select
@@ -164,6 +208,7 @@ const CreateSubjectView: React.FC = () => {
                 ))}
               </select>
             </div>
+
             <div className={styles.inputGroup}>
               <label className={styles.label}>Materia Opcional *</label>
               <BooleanInput
@@ -180,11 +225,24 @@ const CreateSubjectView: React.FC = () => {
           <div className={styles.buttonGroup}>
             <Button type="submit" variant="primary" disabled={loading}>
               <FaSave className={styles.buttonIcon} />
-              {loading ? "Cargando..." : "Crear Materia"}
+              {loading
+                ? isEditMode
+                  ? "Actualizando..."
+                  : "Creando..."
+                : isEditMode
+                ? "Actualizar Materia"
+                : "Crear Materia"}
             </Button>
-            <Button type="button" variant="outline" disabled={loading}>
-              Cancelar
-            </Button>
+            {isEditMode && (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={loading}
+                onClick={handleCancel}
+              >
+                Cancelar
+              </Button>
+            )}
           </div>
         </form>
       </Card>

--- a/src/admin/views/Subject/ListSubjectView.module.css
+++ b/src/admin/views/Subject/ListSubjectView.module.css
@@ -1,6 +1,7 @@
 .container {
   max-width: 1200px;
   margin: 0 auto;
+  padding: 1rem;
 }
 
 .header {
@@ -13,28 +14,43 @@
 
 .title {
   font-size: 2rem;
-  font-weight: bold;
-  color: #2e2e2e;
+  font-weight: 700;
+  color: #1f2937;
   margin-bottom: 0.5rem;
 }
 
 .subtitle {
   color: #6b7280;
   font-size: 1rem;
+  line-height: 1.5;
 }
 
 .buttonIcon {
   margin-right: 0.5rem;
 }
 
-.searchCard {
+.tableCard {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  border: 1px solid #e5e7eb;
+  overflow: hidden;
+}
+
+.searchSection {
   padding: 1.5rem;
-  margin-bottom: 2rem;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
 }
 
 .searchWrapper {
   position: relative;
   max-width: 400px;
+  flex: 1;
 }
 
 .searchIcon {
@@ -42,102 +58,282 @@
   left: 12px;
   top: 50%;
   transform: translateY(-50%);
-  color: #6b7280;
+  color: #9ca3af;
   font-size: 0.875rem;
 }
 
 .searchInput {
   padding-left: 2.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  transition: all 0.2s;
 }
 
-.studentsGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 1.5rem;
+.searchInput:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
-.studentCard {
-  padding: 1.5rem;
-}
-
-.cardHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 1.5rem;
-}
-
-.studentInfo {
-  flex: 1;
-}
-
-.studentName {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #2e2e2e;
-  margin-bottom: 0.25rem;
-}
-
-.enrollment {
-  font-size: 0.875rem;
+.resultsInfo {
   color: #6b7280;
-  font-family: "Courier New", monospace;
-  font-weight: 500;
+  font-size: 0.875rem;
+  white-space: nowrap;
 }
 
-.studentDetails {
+.tableWrapper {
+  overflow-x: auto;
+  min-height: 200px;
+}
+
+.loadingContainer {
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem;
 }
 
-.detailItem {
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.table th {
+  text-align: left;
+  padding: 1rem 1.5rem;
+  font-weight: 600;
+  color: #374151;
+  background: linear-gradient(to bottom, #f9fafb, #f3f4f6);
+  border-bottom: 2px solid #e5e7eb;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.sortableHeader {
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s;
+}
+
+.sortableHeader:hover {
+  background: linear-gradient(to bottom, #f3f4f6, #e5e7eb);
+}
+
+.headerContent {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.875rem;
+}
+
+.sortIcon {
+  color: #9ca3af;
+  font-size: 0.75rem;
+  transition: color 0.2s;
+}
+
+.sortableHeader:hover .sortIcon {
   color: #6b7280;
 }
 
-.detailIcon {
-  width: 1rem;
-  height: 1rem;
+.idColumn {
+  width: 100px;
+}
+
+.nameColumn {
+  width: auto;
+}
+
+.actionsColumn {
+  width: 120px;
+  text-align: center;
+}
+
+.table td {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #f3f4f6;
+  color: #374151;
+  font-size: 0.875rem;
+  vertical-align: middle;
+}
+
+.tableRow {
+  transition: all 0.2s ease;
+  background: white;
+}
+
+.tableRow:hover {
+  background: #f8fafc;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.tableRow:hover td {
+  border-color: #e2e8f0;
+}
+
+.idCell {
+  text-align: center;
+}
+
+.idBadge {
+  display: inline-block;
+  font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+  font-weight: 600;
+  color: #6366f1;
+  background: #f1f5f9;
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  min-width: 40px;
+  text-align: center;
+}
+
+.nameCell {
+  font-weight: 500;
+}
+
+.nameWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.teacherIcon {
+  color: #6366f1;
+  font-size: 1rem;
   flex-shrink: 0;
 }
 
-.email {
-  word-break: break-all;
+.teacherIconUnassigned {
+  color: #9ca3af;
+  font-size: 1rem;
+  flex-shrink: 0;
 }
 
-.cardActions {
+.actionsCell {
+  text-align: center;
+}
+
+.actions {
   display: flex;
-  justify-content: space-between;
+  gap: 0.5rem;
+  justify-content: center;
   align-items: center;
-  padding-top: 1rem;
-  border-top: 1px solid #f3f4f6;
 }
 
-.actionIcon {
-  margin-right: 0.25rem;
+.editButton {
+  color: #059669;
+  border: 1px solid transparent;
+  transition: all 0.2s;
+}
+
+.editButton:hover {
+  background-color: #ecfdf5;
+  border-color: #a7f3d0;
+  color: #047857;
+  transform: scale(1.05);
 }
 
 .deleteButton {
-  color: #ef4444;
+  color: #dc2626;
+  border: 1px solid transparent;
+  transition: all 0.2s;
 }
 
 .deleteButton:hover {
   background-color: #fef2f2;
-  color: #dc2626;
+  border-color: #fecaca;
+  color: #b91c1c;
+  transform: scale(1.05);
+}
+
+.emptyState {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.emptyContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: #6b7280;
+}
+
+.emptyIcon {
+  font-size: 2rem;
+  color: #d1d5db;
+  margin-bottom: 0.5rem;
 }
 
 @media (max-width: 768px) {
+  .container {
+    padding: 0.5rem;
+  }
+
   .header {
     flex-direction: column;
     align-items: stretch;
+    gap: 1rem;
   }
 
-  .studentsGrid {
-    grid-template-columns: 1fr;
+  .searchSection {
+    padding: 1rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .searchWrapper {
+    max-width: none;
+  }
+
+  .resultsInfo {
+    text-align: center;
+  }
+
+  .table th,
+  .table td {
+    padding: 0.75rem 0.5rem;
+    font-size: 0.75rem;
+  }
+
+  .nameWrapper {
+    gap: 0.5rem;
+  }
+
+  .actions {
+    gap: 0.25rem;
+  }
+
+  .headerContent {
+    gap: 0.25rem;
+  }
+
+  .sortIcon {
+    font-size: 0.625rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .table th,
+  .table td {
+    padding: 0.5rem 0.25rem;
+  }
+
+  .idColumn {
+    width: 80px;
+  }
+
+  .actionsColumn {
+    width: 80px;
+  }
+
+  .idBadge {
+    padding: 0.125rem 0.25rem;
+    font-size: 0.75rem;
   }
 }

--- a/src/admin/views/Subject/ListSubjectView.tsx
+++ b/src/admin/views/Subject/ListSubjectView.tsx
@@ -138,7 +138,10 @@ const ListSubjectView: React.FC = () => {
                   : styles.teacherIconUnassigned
               }
             />
-            <span>{subject.teacher?.name || "Sin asignar"}</span>
+            <span>
+              {subject.teacher?.name + " " + subject.teacher?.lastname ||
+                "Sin asignar"}
+            </span>
           </div>
         </div>
       ),

--- a/src/admin/views/Subject/ListSubjectView.tsx
+++ b/src/admin/views/Subject/ListSubjectView.tsx
@@ -17,8 +17,13 @@ import styles from "./ListSubjectView.module.css";
 
 const ListSubjectView: React.FC = () => {
   const navigate = useNavigate();
-  const { loading, getPaginatedSubject, deleteSubject, paginatedSubjects } =
-    useSubject();
+  const {
+    loading,
+    setSelectedSubject,
+    getPaginatedSubject,
+    deleteSubject,
+    paginatedSubjects,
+  } = useSubject();
   const {
     paginationParams,
     handleSearch,
@@ -54,6 +59,7 @@ const ListSubjectView: React.FC = () => {
       isOpen: true,
       showDoubleConfirmation: false,
       onConfirm: () => {
+        setSelectedSubject(subject);
         navigate(`/dashboard/subjects/edit/${subject.id}`);
         setAlertConfig((prev) => ({ ...prev, isOpen: false }));
       },

--- a/src/admin/views/Subject/ListSubjectView.tsx
+++ b/src/admin/views/Subject/ListSubjectView.tsx
@@ -1,10 +1,164 @@
 import type React from "react";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
-import { FaGraduationCap, FaTools } from "react-icons/fa";
+import { FaCalendarAlt, FaEdit, FaTrash, FaPlus, FaUser } from "react-icons/fa";
 import Button from "../../../shared/components/Button/ButtonComponent";
+import ConfirmationModal from "../../../shared/components/ConfirmationModal/ConfirmationModal";
+import { DataTable } from "../../../shared/components/DataTable";
+import type {
+  DataTableColumn,
+  DataTableAction,
+} from "../../../shared/components/DataTable";
+import usePaginationParams from "../../../shared/hooks/UsePaginateParams";
+import { useSubject } from "../../hooks/useSubject";
+import type { SubjectResponseDto } from "../../services/subject/SubjectService";
 import styles from "./ListSubjectView.module.css";
 
-const ListStudentView: React.FC = () => {
+const ListSubjectView: React.FC = () => {
+  const navigate = useNavigate();
+  const { loading, getPaginatedSubject, deleteSubject, paginatedSubjects } =
+    useSubject();
+  const {
+    paginationParams,
+    handleSearch,
+    handleSort,
+    handlePageChange,
+    handlePageSizeChange,
+  } = usePaginationParams();
+  const [alertConfig, setAlertConfig] = useState({
+    title: "",
+    message: "",
+    type: "warning" as "warning" | "danger",
+    isOpen: false,
+    showDoubleConfirmation: false,
+    onConfirm: () => {},
+  });
+
+  useEffect(() => {
+    const loadPaginatedSubjects = async () => {
+      try {
+        await getPaginatedSubject(paginationParams);
+      } catch (error) {
+        console.error("Error al cargar materias paginadas:", error);
+      }
+    };
+    loadPaginatedSubjects();
+  }, [paginationParams, getPaginatedSubject]);
+
+  const handleEdit = (subject: SubjectResponseDto) => {
+    setAlertConfig({
+      title: "Modificar Materia",
+      message: `¿Está seguro que desea modificar la materia "${subject.name}"?`,
+      type: "warning",
+      isOpen: true,
+      showDoubleConfirmation: false,
+      onConfirm: () => {
+        navigate(`/dashboard/subjects/edit/${subject.id}`);
+        setAlertConfig((prev) => ({ ...prev, isOpen: false }));
+      },
+    });
+  };
+
+  const handleDelete = (subject: SubjectResponseDto) => {
+    setAlertConfig({
+      title: "Eliminar Materia",
+      message: `¿Está seguro que desea eliminar la materia "${subject.name}"?`,
+      type: "danger",
+      isOpen: true,
+      showDoubleConfirmation: true,
+      onConfirm: async () => {
+        try {
+          //console.log(`Eliminando materia con ID: ${subject.id}`); // TODO: REMOVE_DEBUG
+          await deleteSubject(subject.id);
+          // Recargar la página actual después de eliminar
+          await getPaginatedSubject(paginationParams);
+          setAlertConfig((prev) => ({ ...prev, isOpen: false }));
+        } catch (error) {
+          console.error("Error al eliminar materia:", error);
+        }
+      },
+    });
+  };
+
+  // Definición de columnas para la tabla
+  const columns: DataTableColumn<SubjectResponseDto>[] = [
+    {
+      key: "id",
+      label: "ID",
+      sortable: true,
+      width: "100px",
+      className: styles.idColumn,
+      render: (subject) => <span className={styles.idBadge}>{subject.id}</span>,
+    },
+    {
+      key: "name",
+      label: "Nombre",
+      sortable: true,
+      className: styles.nameColumn,
+      render: (subject) => (
+        <div className={styles.nameCell}>
+          <div className={styles.nameWrapper}>
+            <span>{subject.name}</span>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "course",
+      label: "Curso",
+      sortable: true,
+      className: styles.nameColumn,
+      render: (subject) => (
+        <div className={styles.nameCell}>
+          <div className={styles.nameWrapper}>
+            <span>{subject.course?.name || "Sin asignar"}</span>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "teacher",
+      label: "Profesor",
+      sortable: true,
+      className: styles.nameColumn,
+      render: (subject) => (
+        <div className={styles.nameCell}>
+          <div className={styles.nameWrapper}>
+            <FaUser
+              className={
+                subject.teacher?.name
+                  ? styles.teacherIcon
+                  : styles.teacherIconUnassigned
+              }
+            />
+            <span>{subject.teacher?.name || "Sin asignar"}</span>
+          </div>
+        </div>
+      ),
+    },
+  ];
+
+  // Definición de acciones para la tabla
+  const actions: DataTableAction<SubjectResponseDto>[] = [
+    {
+      label: "Editar",
+      icon: <FaEdit />,
+      onClick: handleEdit,
+      variant: "ghost",
+      className: styles.editButton,
+      title: "Modificar materia",
+    },
+    {
+      label: "Eliminar",
+      icon: <FaTrash />,
+      onClick: handleDelete,
+      variant: "ghost",
+      className: styles.deleteButton,
+      title: "Eliminar materia",
+    },
+  ];
+
   const containerVariants = {
     hidden: { opacity: 0 },
     visible: {
@@ -29,21 +183,70 @@ const ListStudentView: React.FC = () => {
     >
       <motion.div variants={itemVariants} className={styles.header}>
         <div>
-          <div className={styles.constructionBanner}>
-            <FaTools className={styles.constructionIcon} />
-            <h1 className={styles.title}>
-              Visualización de Materias - En Construcción
-            </h1>
-            <p className={styles.subtitle}>Esta página está en desarrollo.</p>
-          </div>
+          <h1 className={styles.title}>Gestión de Materias</h1>
+          <p className={styles.subtitle}>
+            Administra las materias pertenecientes a cursos en particular
+          </p>
         </div>
-        <Button variant="primary">
-          <FaGraduationCap className={styles.buttonIcon} />
+        <Button
+          variant="primary"
+          onClick={() => navigate("/dashboard/subjects/create")}
+        >
+          <FaPlus className={styles.buttonIcon} />
           Nueva Materia
         </Button>
       </motion.div>
+
+      <motion.div variants={itemVariants}>
+        <DataTable
+          data={paginatedSubjects?.results || []}
+          columns={columns}
+          actions={actions}
+          loading={loading}
+          searchable={true}
+          searchPlaceholder="Buscar materias..."
+          searchValue={paginationParams.search || ""}
+          onSearchChange={handleSearch}
+          sortBy={paginationParams.order_by}
+          sortOrder={paginationParams.order_type}
+          onSort={handleSort}
+          emptyStateIcon={<FaCalendarAlt />}
+          emptyStateTitle="No se encontraron materias"
+          emptyStateSubtitle={
+            paginationParams.search
+              ? "Intenta con otros términos de búsqueda"
+              : "Comienza creando una nueva materia"
+          }
+          loadingText="Cargando materias..."
+          totalItems={paginatedSubjects?.count}
+          getRowKey={(subject) => subject.id}
+          pagination={
+            paginatedSubjects
+              ? {
+                  currentPage: paginatedSubjects.currentPage,
+                  totalPages: paginatedSubjects.totalPages,
+                  pageSize: paginatedSubjects.pageSize,
+                  totalItems: paginatedSubjects.count,
+                  onPageChange: handlePageChange,
+                  onPageSizeChange: handlePageSizeChange,
+                }
+              : undefined
+          }
+        />
+      </motion.div>
+
+      <ConfirmationModal
+        title={alertConfig.title}
+        message={alertConfig.message}
+        type={alertConfig.type}
+        isOpen={alertConfig.isOpen}
+        showDoubleConfirmation={alertConfig.showDoubleConfirmation}
+        doubleConfirmationText="¿Está completamente seguro? Esta acción no se puede deshacer."
+        onConfirm={alertConfig.onConfirm}
+        onClose={() => setAlertConfig((prev) => ({ ...prev, isOpen: false }))}
+      />
     </motion.div>
   );
 };
 
-export default ListStudentView;
+export default ListSubjectView;


### PR DESCRIPTION
# Descripción
Se créo el listado de materias para el administrador

# Explicación
Así como hicimos con año, curso y docente, ya estaría "lista" la vista de materias. Digo "lista", porque podríamos charlar un par de cosas en cuanto a qué y cómo podría ver exactamente las cosas el administrador.

# Problemas Encontrados
En el product backlog, tenemos el siguiente criterio de aceptación en Gestionar Materia:

> Se debe poder listar todas las materias creadas, mostrando el nombre, el docente que la dictamina, y el curso al que pertenecen.

Esta bien, pero el problema es que en este momento el listar materias esta trayendo todas (bueno, las 10 primeras por paginación) las materias en sí. No estaría pudiendo filtrar por año (por ejemplo), y dentro de año, por curso.

Por eso se me ocurre que podríamos agregar esta opción, tipo un cuadrito dentro del DataTable que puedas indicar de qué año querrías traer las materias. Por lo menos eso, porque por curso ya lo puede ver en la tabla ponele y puede filtrar bien.

Si te parece bien, lo vemos en la siguiente reunión con todos, o entre nosotros.

# Issue Relacionada
Closes #41 
