### PR TITLE
[#77] fix: Modificar año

### DIFF
--- a/src/admin/contexts/yearContext/YearContext.type.ts
+++ b/src/admin/contexts/yearContext/YearContext.type.ts
@@ -18,4 +18,6 @@ export interface YearContextType {
   deleteYear: (id: number) => Promise<void>;
   years: YearResponseDto[];
   paginatedYears: PaginatedData<YearResponseDto> | null;
+  selectedYear: YearResponseDto | null;
+  setSelectedYear: React.Dispatch<React.SetStateAction<YearResponseDto | null>>;
 }

--- a/src/admin/contexts/yearContext/YearProvider.tsx
+++ b/src/admin/contexts/yearContext/YearProvider.tsx
@@ -21,6 +21,9 @@ export const YearProvider: React.FC<YearProviderProps> = ({ children }) => {
   const [years, setYears] = useState<YearResponseDto[]>([]);
   const [paginatedYears, setPaginatedYears] =
     useState<PaginatedData<YearResponseDto> | null>(null);
+  const [selectedYear, setSelectedYear] = useState<YearResponseDto | null>(
+    null
+  );
 
   const registerYear = async (data: CreateYearPayload): Promise<void> => {
     setLoading(true);
@@ -102,6 +105,7 @@ export const YearProvider: React.FC<YearProviderProps> = ({ children }) => {
 
   const contextValue: YearContextType = {
     loading,
+    setSelectedYear,
     registerYear,
     updateYear,
     getYear,
@@ -110,6 +114,7 @@ export const YearProvider: React.FC<YearProviderProps> = ({ children }) => {
     deleteYear,
     years,
     paginatedYears,
+    selectedYear,
   };
 
   return (

--- a/src/admin/views/Year/CreateYearView.tsx
+++ b/src/admin/views/Year/CreateYearView.tsx
@@ -1,7 +1,6 @@
 import type React from "react";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-// import { useLocation } from "react-router-dom"; // DEBUG: Para testear sin los cambios del backend
 import { motion } from "framer-motion";
 import { FaCalendarAlt, FaSave } from "react-icons/fa";
 import Card from "../../../shared/components/Card/CardComponent";
@@ -16,22 +15,14 @@ const CreateYearView: React.FC = () => {
   const isEditMode = Boolean(id);
 
   const [formData, setFormData] = useState({ name: "" });
-  const { registerYear, updateYear, getYearById, loading } = useYear(); // DEBUG: { registerYear, updateYear, loading }
-
-  // DEBUG: Para testear sin los cambios del backend
-  // const location = useLocation();
-  // const yearNameFromState = location.state?.yearName;
+  const { registerYear, updateYear, getYearById, loading, selectedYear } =
+    useYear();
 
   useEffect(() => {
     if (isEditMode && id) {
       const loadYearData = async () => {
         try {
-          // DEBUG: Para probar sin los cambios del backend
-          // if (yearNameFromState) {
-          //   setFormData({ name: yearNameFromState });
-          // }
-          const yearData = await getYearById(Number(id));
-          setFormData({ name: yearData.name });
+          setFormData({ name: selectedYear?.name || "" });
         } catch (error) {
           console.error("Error al cargar el año:", error);
           navigate("/dashboard/years/list");
@@ -39,10 +30,10 @@ const CreateYearView: React.FC = () => {
       };
       loadYearData();
     }
-  }, [id, isEditMode, getYearById, navigate]); // DEBUG: [id, isEditMode, yearNameFromState, navigate]
+  }, [id, isEditMode, getYearById, navigate]);
 
   const handleChange = (field: string, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
+    setFormData((prev) => ({ ...prev, [field]: value || "" }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -103,7 +94,7 @@ const CreateYearView: React.FC = () => {
               <label className={styles.label}>Nombre del Año *</label>
               <Input
                 placeholder="Ej: Primer Año"
-                value={formData.name}
+                value={formData.name || ""}
                 onChange={(e) => handleChange("name", e.target.value)}
                 required
               />

--- a/src/admin/views/Year/ListYearView.tsx
+++ b/src/admin/views/Year/ListYearView.tsx
@@ -17,7 +17,13 @@ import styles from "./ListYearView.module.css";
 
 const ListYearView: React.FC = () => {
   const navigate = useNavigate();
-  const { loading, getPaginatedYear, deleteYear, paginatedYears } = useYear();
+  const {
+    loading,
+    setSelectedYear,
+    getPaginatedYear,
+    deleteYear,
+    paginatedYears,
+  } = useYear();
   const {
     paginationParams,
     handleSearch,
@@ -53,10 +59,7 @@ const ListYearView: React.FC = () => {
       isOpen: true,
       showDoubleConfirmation: false,
       onConfirm: () => {
-        // DEBUG: Para probar sin los cambios del backend
-        // navigate(`/dashboard/years/edit/${year.id}`, {
-        //   state: { yearName: year.name },
-        // });
+        setSelectedYear(year);
         navigate(`/dashboard/years/edit/${year.id}`);
         setAlertConfig((prev) => ({ ...prev, isOpen: false }));
       },


### PR DESCRIPTION
# Descripción
Se arregló el modificar año

# Explicación
Me estaba apareciendo un error de atributo no controlado / controlado de React. Para arreglarlo, simplemente agregue un "selectedYear" al provider para que, antes de navegar a editar el año, se guarde globalmente en un estado el año que se va a modificar.

# Issue relacionada
Closes #77 