### PR TITLE
[#95 <- #111] refactor: Materias de configuración general de actividad

### DIFF
--- a/src/activity/views/configurationView/ConfigureActivityView.tsx
+++ b/src/activity/views/configurationView/ConfigureActivityView.tsx
@@ -45,12 +45,12 @@ const ConfigureActivityView: React.FC = () => {
   const [errors, setErrors] = useState<ConfigurationErrors>({});
   const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [isVerticalLayout, setIsVerticalLayout] = useState(false);
-  const { subjects, getSubject } = useSubject();
+  const { subjects, getSubjectByTeacher } = useSubject();
   const { registerConfigurationActivity } = useConfigurationActivity();
   const navigate = useNavigate();
 
   useEffect(() => {
-    getSubject();
+    getSubjectByTeacher();
   }, []);
 
   // Mapeo de nombres de actividades TODO: Traerlo bien de otro lado

--- a/src/admin/contexts/subjectContext/SubjectProvider.tsx
+++ b/src/admin/contexts/subjectContext/SubjectProvider.tsx
@@ -67,7 +67,6 @@ export const SubjectProvider: React.FC<SubjectProviderProps> = ({
     setLoading(true);
     try {
       const response = await SubjectService.getSubjectByTeacherApi();
-      console.log(response.data.data);
       setSubjects(response.data.data);
     } catch (error) {
       console.error("Error al obtener las materias:", error); // TODO: REMOVE_DEBUG

--- a/src/admin/views/Subject/CreateSubjectView.tsx
+++ b/src/admin/views/Subject/CreateSubjectView.tsx
@@ -20,7 +20,7 @@ const CreateSubjectView: React.FC = () => {
 
   const { getYear, years } = useYear();
   const { getCourse, courses } = useCourse();
-  const { getTeacher, teachers } = useTeacher();
+  const { getTeacher, teacher } = useTeacher();
   const { registerSubject, updateSubject, loading, selectedSubject } =
     useSubject();
 
@@ -201,7 +201,7 @@ const CreateSubjectView: React.FC = () => {
                 }
               >
                 <option value="">Seleccionar docente</option>
-                {teachers.map((teacher) => (
+                {teacher.map((teacher) => (
                   <option value={teacher.id} key={teacher.id}>
                     {teacher.name}
                   </option>


### PR DESCRIPTION
# Descripción
Se cambió las materias que ve el docente para crear una actividad a solo materias en las que participa.

# Problemas encontrados
Cuando fui a agregar una materia para el docente que uso, me di cuenta había un error en la creación de una materia. Esperaba teachers y el estado global tiene teacher para todos los docentes, asique lo fixie acá mismo. Son dos lineas en la view de CreateSubjectView.

# Issue relacionada
Closes #111 