### PR TITLE
[#144] feat: Test del componente createCourseView

### DIFF
--- a/src/test/admin/views/course/CreateCourseView.test.tsx
+++ b/src/test/admin/views/course/CreateCourseView.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, type Mock } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import CreateCourseView from "../../../../admin/views/Course/CreateCourseView";
+import { CourseProvider } from "../../../../admin/contexts/courseContext/CourseProvider";
+
+// ----- Mocks del hook de cursos -----
+const registerCourseMock = vi.fn();
+
+vi.mock("../../../../admin/hooks/useCourse", () => ({
+  useCourse: () => ({
+    registerCourse: registerCourseMock,
+    loading: false,
+    selectedCourse: null, // Para crear (se seteará en editar)
+  }),
+}));
+
+const getYearMock = vi.fn();
+vi.mock("../../../../admin/hooks/useYear", () => ({
+  useYear: () => ({
+    years: [
+      { id: 1, name: "Primero" },
+      { id: 2, name: "Segundo" },
+    ],
+    getYear: getYearMock,
+    loading: false,
+  }),
+}));
+
+// ----- Mock de alert -----
+vi.spyOn(window, "alert").mockImplementation(() => {});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({}),
+  };
+});
+
+const renderCreateCourseView = () =>
+  render(
+    <MemoryRouter>
+      <CourseProvider>
+        <CreateCourseView />
+      </CourseProvider>
+    </MemoryRouter>
+  );
+
+describe("CreateCourseView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Escenario 1: crear un curso válido", async () => {
+    const { useCourse } = await import("../../../../admin/hooks/useCourse");
+    const registerCourseMock = useCourse().registerCourse as Mock;
+
+    renderCreateCourseView();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Nombre del curso. Ejemplo: A"),
+      {
+        target: { value: "D" },
+      }
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: 1 },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /crear curso/i }));
+
+    await waitFor(() => {
+      expect(registerCourseMock).toHaveBeenCalledWith({
+        name: "D",
+        year_id: 1,
+      });
+      expect(window.alert).toHaveBeenCalledWith("Curso creado exitosamente.");
+    });
+  });
+
+  it("Escenario 2: Intentar crear curso con nombre duplicado en el mismo año", async () => {
+    const { useCourse } = await import("../../../../admin/hooks/useCourse");
+    const registerCourseMock = useCourse().registerCourse as Mock;
+
+    //SIMULAR ERROR
+    registerCourseMock.mockRejectedValueOnce(
+      new Error("Ya existe un curso con ese nombre en este año.") //MENSAJE QUE DEBERIA APARECER TRAS EL ERROR
+    );
+
+    renderCreateCourseView();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Nombre del curso. Ejemplo: A"),
+      {
+        target: { value: "D" },
+      }
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: 1 } });
+
+    fireEvent.click(screen.getByRole("button", { name: /crear curso/i }));
+
+    await waitFor(() => {
+      expect(registerCourseMock).toHaveBeenCalled();
+      expect(window.alert).toHaveBeenCalledWith(
+        "Hubo un error al crear el Curso." //MENSAJE QUE SE MUESTRA AHORA
+      );
+    });
+  });
+
+  it("Escenario 3: Intentar crear curso con nombre vacío", async () => {
+    const { useCourse } = await import("../../../../admin/hooks/useCourse");
+    const registerCourseMock = useCourse().registerCourse as Mock;
+
+    renderCreateCourseView();
+    const input = screen.getByPlaceholderText("Nombre del curso. Ejemplo: A");
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "1" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /crear curso/i }));
+
+    expect(registerCourseMock).not.toHaveBeenCalled(); //valida que no se llame la funcion registrar
+    expect(input).toBeRequired(); // Comprueba que el input tenga required
+  });
+
+  it("Escenario 4: Intentar crear curso con nombre de mas de 50 caracteres", async () => {
+    const { useCourse } = await import("../../../../admin/hooks/useCourse");
+    const registerCourseMock = useCourse().registerCourse as Mock;
+
+    renderCreateCourseView();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Nombre del curso. Ejemplo: A"),
+      {
+        target: { value: "a".repeat(51) },
+      }
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: 1 } });
+
+    fireEvent.click(screen.getByRole("button", { name: /crear curso/i }));
+
+    expect(registerCourseMock).not.toHaveBeenCalled();
+    // expect(
+    //   await screen.findByText("El nombre no puede superar los 50 caracteres.")
+    // ).toBeInTheDocument();
+  });
+
+  it("Escenario 5: Intentar crear curso con caracteres inválidos", async () => {
+    const { useCourse } = await import("../../../../admin/hooks/useCourse");
+    const registerCourseMock = useCourse().registerCourse as Mock;
+
+    renderCreateCourseView();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Nombre del curso. Ejemplo: A"),
+      {
+        target: { value: "Curso#1!!" },
+      }
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: 1 } });
+
+    fireEvent.click(screen.getByRole("button", { name: /crear curso/i }));
+
+    expect(registerCourseMock).not.toHaveBeenCalled();
+    // expect(
+    //   await screen.findByText("El nombre solo puede contener letras y números.")
+    // ).toBeInTheDocument();
+  });
+});

--- a/src/test/admin/views/course/EditCourseView.test.tsx
+++ b/src/test/admin/views/course/EditCourseView.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, type Mock } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import CreateCourseView from "../../../../admin/views/Course/CreateCourseView";
+import { CourseProvider } from "../../../../admin/contexts/courseContext/CourseProvider";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    useParams: () => ({ id: 1 }),
+  };
+});
+
+// ----- Mocks del hook de cursos -----
+const updateCourseMock = vi.fn();
+vi.mock("../../../../admin/hooks/useCourse", () => ({
+  useCourse: () => ({
+    updateCourse: updateCourseMock,
+    loading: false,
+    selectedCourse: null,
+  }),
+}));
+
+const getYearMock = vi.fn();
+vi.mock("../../../../admin/hooks/useYear", () => ({
+  useYear: () => ({
+    years: [
+      { id: 1, name: "Primero" },
+      { id: 2, name: "Segundo" },
+    ],
+    getYear: getYearMock,
+    loading: false,
+  }),
+}));
+
+// ----- Mock de alert -----
+vi.spyOn(window, "alert").mockImplementation(() => {});
+
+const renderCreateCourseView = () =>
+  render(
+    <MemoryRouter>
+      <CourseProvider>
+        <CreateCourseView />
+      </CourseProvider>
+    </MemoryRouter>
+  );
+
+describe("CreateCourseView (EDIT)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Escenario 6: Editar el nombre de un curso existente", async () => {
+    const { useCourse } = await import("../../../../admin/hooks/useCourse");
+    const updateCourseMock = useCourse().updateCourse as Mock;
+
+    renderCreateCourseView();
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      //Cargamos el input con el year
+      target: { value: 1 },
+    });
+
+    const input = screen.getByPlaceholderText("Nombre del curso. Ejemplo: A");
+    fireEvent.change(input, { target: { value: "F" } });
+
+    const button = screen.getByRole("button", { name: /actualizar curso/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(updateCourseMock).toHaveBeenCalledWith({
+        name: "F",
+        id: 1,
+        year_id: 1,
+      });
+      expect(window.alert).toHaveBeenCalledWith(
+        "Curso actualizado exitosamente."
+      );
+    });
+    console.log(updateCourseMock.mock.calls);
+  });
+
+  it("Escenario 7: Intentar modificar el año de un curso", async () => {
+    renderCreateCourseView();
+
+    const select = screen.getByRole("combobox");
+    expect(select).toBeDisabled(); // el año no editable
+  });
+});


### PR DESCRIPTION
# Descripción
Se realizo el test al componente de createCourseView, el cual también contiene la logica del edit

Escenarios testeados
Escenario 1: crear un curso válido
Escenario 2: Intentar crear curso con nombre duplicado en el mismo año
Escenario 3: Intentar crear curso con nombre vacío
Escenario 4: Intentar crear curso con nombre de mas de 50 caracteres
Escenario 5: Intentar crear curso con caracteres inválidos
Escenario 6: Editar el nombre de un curso existente
Escenario 7: Intentar modificar el año de un curso
## Resultado obtenidos
<img width="616" height="321" alt="image" src="https://github.com/user-attachments/assets/c716e0b8-13a9-419d-975b-851cd16a8516" />

## Conclusión
Realizar los refactor necesarios para solucionar el escenario 4, 5 y 7