### PR TITLE
[#95 <- #149] feat: Agregar initialBalance

### DIFF
--- a/src/activity/types/Configuration.type.ts
+++ b/src/activity/types/Configuration.type.ts
@@ -6,6 +6,7 @@ export interface ConfigurationActivity {
   maxTime: number;
   subjectId: number;
   attempts: number;
+  initialBalance: number;
 }
 
 export type ConfigurationErrors = {
@@ -16,4 +17,5 @@ export type ConfigurationErrors = {
   maxTime?: string;
   subjectId?: string;
   attempts?: string;
+  initialBalance?: string;
 };

--- a/src/activity/views/configurationView/ConfigureActivityView.module.css
+++ b/src/activity/views/configurationView/ConfigureActivityView.module.css
@@ -292,12 +292,17 @@
 
 .timeInput {
   padding-left: 2.5rem !important;
-  padding-right: 3rem !important;
+  padding-right: 2.5rem !important;
 }
 
 .attemptsInput {
   padding-left: 2.5rem !important;
-  padding-right: 4.5rem !important;
+  padding-right: 4.25rem !important;
+}
+
+.rewardInput {
+  padding-left: 2.5rem !important;
+  padding-right: 4.75rem !important;
 }
 
 .dcUnit {

--- a/src/activity/views/configurationView/ConfigureActivityView.tsx
+++ b/src/activity/views/configurationView/ConfigureActivityView.tsx
@@ -157,6 +157,13 @@ const ConfigureActivityView: React.FC = () => {
       newErrors.initialBalance = "El balance inicial debe ser mayor a 0";
     }
 
+    const selectedSubject = getSelectedSubject();
+    const ssActualBalance = selectedSubject?.actualBalance || 0;
+    if (configuration.initialBalance > ssActualBalance) {
+      newErrors.initialBalance =
+        "El balance inicial debe ser mayor al balance actual de la materia";
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };

--- a/src/activity/views/configurationView/ConfigureActivityView.tsx
+++ b/src/activity/views/configurationView/ConfigureActivityView.tsx
@@ -16,6 +16,8 @@ import {
   FaList,
   FaGamepad,
   FaRedoAlt,
+  FaAward,
+  FaCoins,
 } from "react-icons/fa";
 import type {
   ConfigurationActivity,
@@ -39,12 +41,13 @@ const ConfigureActivityView: React.FC = () => {
     maxTime: 30,
     subjectId: 0,
     attempts: 1,
+    initialBalance: 0,
   });
 
   const { code_game } = useParams();
   const [errors, setErrors] = useState<ConfigurationErrors>({});
   const [isPreviewMode, setIsPreviewMode] = useState(false);
-  const [isVerticalLayout, setIsVerticalLayout] = useState(false);
+  const [isVerticalLayout, setIsVerticalLayout] = useState(true);
   const { subjects, getSubjectByTeacher } = useSubject();
   const { registerConfigurationActivity } = useConfigurationActivity();
   const navigate = useNavigate();
@@ -150,6 +153,10 @@ const ConfigureActivityView: React.FC = () => {
       newErrors.attempts = "El numero de intentos debe ser mayor a 0";
     }
 
+    if (configuration.initialBalance <= 0) {
+      newErrors.initialBalance = "El balance inicial debe ser mayor a 0";
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -174,6 +181,15 @@ const ConfigureActivityView: React.FC = () => {
   const getDifficultyLabel = (value: string) => {
     const option = difficultyOptions.find((opt) => opt.value === value);
     return option ? option.label : value;
+  };
+
+  const getMaximumInitialBalance = () => {
+    const selectedSubject = getSelectedSubject();
+    if (selectedSubject) {
+      return selectedSubject.initialBalance * 0.3;
+    } else {
+      return 1;
+    }
   };
 
   const containerVariants = {
@@ -488,6 +504,48 @@ const ConfigureActivityView: React.FC = () => {
                   </div>
                 </Card>
               </motion.div>
+
+              {/* Recompensa */}
+              <motion.div
+                variants={itemVariants}
+                className={styles.formSection}
+              >
+                <Card className={styles.formCard}>
+                  <div className={styles.cardHeader}>
+                    <FaAward className={styles.cardIcon} />
+                    <h3 className={styles.cardTitle}>Recompensa</h3>
+                  </div>
+                  <div className={styles.cardContent}>
+                    <div className={styles.inputGroup}>
+                      <label className={styles.label}>
+                        Balance Inicial
+                        <span className={styles.labelHint}>
+                          Cantidad de recompensa que entregará la actividad si
+                          es aprobada
+                        </span>
+                      </label>
+                      <div className={styles.dcInputWrapper}>
+                        <FaCoins className={styles.dcIcon} />
+                        <Input
+                          type="number"
+                          value={configuration.initialBalance}
+                          onChange={(e) =>
+                            handleInputChange(
+                              "initialBalance",
+                              Number.parseInt(e.target.value) || 0
+                            )
+                          }
+                          disabled={!configuration.subjectId}
+                          error={errors.initialBalance}
+                          max={getMaximumInitialBalance()}
+                          className={styles.rewardInput}
+                        />
+                        <span className={styles.dcUnit}>monedas</span>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              </motion.div>
             </div>
 
             <motion.div
@@ -552,13 +610,7 @@ const ConfigureActivityView: React.FC = () => {
                     <FaChartLine className={styles.previewIcon} />
                     <div>
                       <h4>Dificultad</h4>
-                      <Badge
-                        variant="primary"
-                        // className={{
-                        //   backgroundColor: getDifficultyColor(),
-                        //   color: "white",
-                        // }}
-                      >
+                      <Badge variant="primary">
                         {getDifficultyLabel(configuration.dificulty) ||
                           "Sin definir"}
                       </Badge>

--- a/src/admin/services/subject/SubjectService.ts
+++ b/src/admin/services/subject/SubjectService.ts
@@ -29,6 +29,8 @@ export interface SubjectResponseDto {
   course: CourseResponseDto;
   teacher: TeacherResponseDto;
   optional: boolean;
+  actualBalance: number;
+  initialBalance: number;
 }
 
 export interface PaginatedSubjectResponse {


### PR DESCRIPTION
# Descripción
Se agregó el atributo initialBalance a la configuración general de actividades.

# Explicación
Se modificó el SubjectResponseDto para que también devuelva el actualBalance y initialBalance de la matería, Esto es necesario porque el initialBalance de la actividad no puede superar el 30% de este balance. Además, debe ser mayor al actualBalance de la materia (obviamente)

Si no se ha elegido materia aún, no se puede tipera en el balance.
<img width="845" height="433" alt="image" src="https://github.com/user-attachments/assets/09be38c6-7b2e-4b16-a408-c05c2ba3f891" />
<img width="806" height="458" alt="image" src="https://github.com/user-attachments/assets/65936748-785b-4a2b-92ed-da513f83de2b" />

# Issue relacionada
Closes #149 
