### PR TITLE
[#219] feat: Agregar filtrado por actividades desaprobadas del estudiante

### DIFF
--- a/src/student/adapters/activityAdapter.ts
+++ b/src/student/adapters/activityAdapter.ts
@@ -16,6 +16,7 @@ export function mapActivityToUI(
       month: "2-digit",
     });
   };
+
   return {
     id: activity.id,
     name: activity.name,
@@ -35,6 +36,7 @@ export function mapActivityToUI(
     reward: isNotApproved ? undefined : `${activity.reward} pts`,
 
     attemptsLabel: `${activity.remainingAttempts} / ${activity.attempts} intentos`,
+    remainingAttempts: activity.remainingAttempts,
     noAttempts: activity.remainingAttempts === 0,
     dueDateLabel:
       isNotApproved && activity.status === "PUBLISHED"

--- a/src/student/components/studentActivitiesViewComponents/activityFilters/ActivityFilters.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityFilters/ActivityFilters.tsx
@@ -1,16 +1,22 @@
 import { motion } from "framer-motion";
 import { FaFilter, FaBook, FaSignal } from "react-icons/fa";
+import type { FilterOption } from "../../../context/activityStudentContext/activityStudentContextUI/ActivityStudentContextUI.type";
 import Button from "../../../../shared/components/Button/ButtonComponent";
 import Card from "../../../../shared/components/Card/CardComponent";
-import styles from "./ActivityFilters.module.css";
 import { useActivityStudentUI } from "../../../hooks/useActivityStudentUI";
-import type { FilterOption } from "../../../context/activityStudentContext/activityStudentContextUI/ActivityStudentContextUI.type";
+import styles from "./ActivityFilters.module.css";
+
 interface ActivityFiltersProps {
-  activeFilter: "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED";
+  activeFilter:
+    | "CREATED"
+    | "PUBLISHED"
+    | "EXPIRED"
+    | "APPROVED"
+    | "DISAPPROVED";
   selectedSubject: FilterOption | null;
   selectedDifficulty: string;
   onFilterChange: (
-    filter: "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED"
+    filter: "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED" | "DISAPPROVED"
   ) => void;
   onSubjectChange: (subject: FilterOption | null) => void;
   onDifficultyChange: (difficulty: string) => void;

--- a/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentContextUI.type.ts
+++ b/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentContextUI.type.ts
@@ -27,7 +27,6 @@ export interface ActivityStudentContextUIType {
   filteredActivities: any[];
   pendingCount: number;
   defeatedCount: number;
-  disapprovedCount: number;
   stats: any[];
   statusFilters: { key: string; label: string; emoji: React.ReactNode }[];
   subjects: FilterOption[];

--- a/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentContextUI.type.ts
+++ b/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentContextUI.type.ts
@@ -6,9 +6,16 @@ export interface FilterOption {
   name: string;
 }
 export interface ActivityStudentContextUIType {
-  activeFilter: "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED";
+  activeFilter:
+    | "CREATED"
+    | "PUBLISHED"
+    | "EXPIRED"
+    | "APPROVED"
+    | "DISAPPROVED";
   setActiveFilter: React.Dispatch<
-    React.SetStateAction<"CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED">
+    React.SetStateAction<
+      "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED" | "DISAPPROVED"
+    >
   >;
 
   selectedSubject: FilterOption | null;
@@ -20,6 +27,7 @@ export interface ActivityStudentContextUIType {
   filteredActivities: any[];
   pendingCount: number;
   defeatedCount: number;
+  disapprovedCount: number;
   stats: any[];
   statusFilters: { key: string; label: string; emoji: React.ReactNode }[];
   subjects: FilterOption[];

--- a/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
@@ -150,7 +150,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
 
     // Contador de desaprobadas - actividades sin intentos restantes
     const disapproved = activityNotApproved.filter(
-      (a) => a.attempts === 0
+      (a) => a.remainingAttempts === 0
     ).length;
 
     return { pending, expired, approved, disapproved };

--- a/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
@@ -12,13 +12,13 @@ import {
   FaFlagCheckered,
   FaBan,
 } from "react-icons/fa";
-import { ActivityStudentContextUI } from "./ActivityStudentContextUI";
-import { useActivityStudent } from "../../../hooks/useActivityStudentAPI";
-import { mapActivityToUI } from "../../../adapters/activityAdapter";
 import { FiX, FiXCircle } from "react-icons/fi";
-import type { ActivityUI } from "../../../types/Activity.type";
-import usePaginationParams from "../../../../shared/hooks/usePaginateParams";
+import { ActivityStudentContextUI } from "./ActivityStudentContextUI";
 import type { FilterOption } from "./ActivityStudentContextUI.type";
+import type { ActivityUI } from "../../../types/Activity.type";
+import { mapActivityToUI } from "../../../adapters/activityAdapter";
+import { useActivityStudent } from "../../../hooks/useActivityStudentAPI";
+import usePaginationParams from "../../../../shared/hooks/usePaginateParams";
 
 export interface PaginationInfo {
   currentPage: number;
@@ -28,6 +28,7 @@ export interface PaginationInfo {
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
 }
+
 interface ProviderProps {
   children: ReactNode;
 }
@@ -45,6 +46,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     getPaginatedActivitiesApproved,
     getPaginatedActivitiesNotApproved,
   } = useActivityStudent();
+
   const {
     paginationParams,
     handlePageChange,
@@ -56,15 +58,15 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   const [activeFilter, setActiveFilter] = useState<
     "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED" | "DISAPPROVED"
   >("PUBLISHED");
+
   const [selectedSubject, setSelectedSubject] = useState<FilterOption | null>(
     null
   );
+
   const difficulties = ["ALL", "FACIL", "MEDIO", "DIFICIL"];
-  const [selectedDifficulty, setSelectedDifficulty] =
-    useState<string>("PUBLISHED");
+  const [selectedDifficulty, setSelectedDifficulty] = useState<string>("ALL");
 
   // Fetch inicial para estadisticas
-  // Este get se realiza para poder obtener las estadisticas, hasta que del back manden direcamente las estadisticas
   useEffect(() => {
     if (activityNotApproved.length <= 0) {
       getActivityApproved();
@@ -76,17 +78,33 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     const filters: string[] = [];
     const filtersValues: string[] = [];
 
-    // status filter
-    if (activeFilter === "EXPIRED" || activeFilter === "PUBLISHED") {
-      filters.push("status");
-      filtersValues.push(activeFilter);
+    // Actividades aprobadas
+    if (activeFilter === "APPROVED") {
+      await getPaginatedActivitiesApproved({
+        ...paginationParams,
+        filters:
+          selectedSubject && selectedSubject.name !== "ALL"
+            ? ["subjectId"]
+            : [],
+        filtersValues:
+          selectedSubject && selectedSubject.name !== "ALL"
+            ? [selectedSubject.id]
+            : [],
+      });
+      return;
     }
 
-    // disapproved filter
+    // Actividades no aprobadas
     if (activeFilter === "DISAPPROVED") {
+      // Desaprobadas: remainingAttempts === 0
       filters.push("disapproved");
       filtersValues.push("true");
-    } else if (activeFilter === "EXPIRED" || activeFilter === "PUBLISHED") {
+    } else {
+      // PUBLISHED, EXPIRED, CREATED
+      filters.push("status");
+      filtersValues.push(activeFilter);
+
+      // No agregar DISAPPROVED
       filters.push("disapproved");
       filtersValues.push("false");
     }
@@ -103,20 +121,11 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
       filtersValues.push(selectedDifficulty);
     }
 
-    // decide qué endpoint llamar
-    if (activeFilter === "APPROVED") {
-      await getPaginatedActivitiesApproved({
-        ...paginationParams,
-        filters,
-        filtersValues,
-      });
-    } else {
-      await getPaginatedActivitiesNotApproved({
-        ...paginationParams,
-        filters,
-        filtersValues,
-      });
-    }
+    await getPaginatedActivitiesNotApproved({
+      ...paginationParams,
+      filters,
+      filtersValues,
+    });
   };
 
   useEffect(() => {
@@ -137,19 +146,27 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     }
     return (paginatedActivitiesNotApproved?.results ?? []).map(mapActivityToUI);
   };
+
   const filteredActivities = getActivitiesUI();
 
   // Stats y contadores
   const getCounts = () => {
+    // Disponibles: PUBLISHED con intentos restantes y NO desaprobadas
     const pending = activityNotApproved.filter(
       (a) => a.status === "PUBLISHED" && a.remainingAttempts > 0
     ).length;
+
+    // Vencidas: EXPIRED con intentos restantes y NO desaprobadas
     const expired = activityNotApproved.filter(
       (a) => a.status === "EXPIRED" && a.remainingAttempts > 0
     ).length;
+
+    // Aprobadas
     const approved = activityApproved.filter(
       (a) => a.state === "APPROVED"
     ).length;
+
+    // Desaprobadas: sin intentos restantes (independiente del status)
     const disapproved = activityNotApproved.filter(
       (a) => a.remainingAttempts === 0
     ).length;
@@ -187,7 +204,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
       bgColor: "#FEE2E2",
     },
     {
-      label: "Vencida",
+      label: "Vencidas",
       value: defeatedCount,
       icon: FiX,
       color: "#b92110ff",
@@ -195,23 +212,25 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     },
   ];
 
-  // Filtros
+  // Filtros de status
   const statusFilters = [
     { key: "PUBLISHED", label: "Disponibles", emoji: <FaStar /> },
     { key: "APPROVED", label: "Aprobadas", emoji: <FaCheck /> },
-    { key: "DESAPROBADAS", label: "Desaprobadas", emoji: <FaBan /> },
+    { key: "DISAPPROVED", label: "Desaprobadas", emoji: <FaBan /> },
     { key: "EXPIRED", label: "Vencidas", emoji: <FiXCircle /> },
   ];
 
   // Materias
   const subjects: FilterOption[] = [
     { id: "ALL", name: "Todas las materias" },
-    ...activityNotApproved
-      .map((a) => ({ id: a.subjectId.toString(), name: a.subjectName }))
-      .filter(
-        (value, index, self) =>
-          index === self.findIndex((s) => s.id === value.id)
-      ),
+    ...Array.from(
+      new Map(
+        [...activityNotApproved, ...activityApproved].map((a) => [
+          a.subjectId.toString(),
+          { id: a.subjectId.toString(), name: a.subjectName },
+        ])
+      ).values()
+    ),
   ];
 
   // Iconos
@@ -278,8 +297,6 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
       default:
         return {
           icon: FaClock,
-          color: "#6B7280",
-          bgColor: "#F3F4F6",
           label: "Desconocido",
           buttonText: "Ver",
           buttonIcon: FaPlay,

--- a/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
@@ -10,6 +10,7 @@ import {
   FaRocket,
   FaMedal,
   FaFlagCheckered,
+  FaTimes,
 } from "react-icons/fa";
 import { ActivityStudentContextUI } from "./ActivityStudentContextUI";
 import { useActivityStudent } from "../../../hooks/useActivityStudentAPI";
@@ -52,9 +53,8 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   } = usePaginationParams();
 
   // Estados locales
-
   const [activeFilter, setActiveFilter] = useState<
-    "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED"
+    "CREATED" | "PUBLISHED" | "EXPIRED" | "APPROVED" | "DISAPPROVED"
   >("PUBLISHED");
   const [selectedSubject, setSelectedSubject] = useState<FilterOption | null>(
     null
@@ -81,16 +81,25 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
       filters.push("status");
       filtersValues.push(activeFilter);
     }
+
+    // disapproved filter
+    if (activeFilter === "DISAPPROVED") {
+      filters.push("disapproved");
+      filtersValues.push("true");
+    }
+
     // subject filter
     if (selectedSubject && selectedSubject.name !== "ALL") {
       filters.push("subjectId");
       filtersValues.push(selectedSubject.id);
     }
+
     // difficulty filter
     if (selectedDifficulty && selectedDifficulty !== "ALL") {
       filters.push("difficulty");
       filtersValues.push(selectedDifficulty);
     }
+
     // decide qué endpoint llamar
     if (activeFilter === "APPROVED") {
       await getPaginatedActivitiesApproved({
@@ -127,7 +136,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   };
   const filteredActivities = getActivitiesUI();
 
-  //Stats y contadores
+  // Stats y contadores
   const getCounts = () => {
     const pending = activityNotApproved.filter(
       (a) => a.status === "PUBLISHED"
@@ -138,13 +147,20 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     const approved = activityApproved.filter(
       (a) => a.state === "APPROVED"
     ).length;
-    return { pending, expired, approved };
+
+    // Contador de desaprobadas - actividades sin intentos restantes
+    const disapproved = activityNotApproved.filter(
+      (a) => a.attempts === 0
+    ).length;
+
+    return { pending, expired, approved, disapproved };
   };
 
   const {
     pending: pendingCount,
     expired: defeatedCount,
     approved: approvedCount,
+    disapproved: disapprovedCount,
   } = getCounts();
 
   const stats = [
@@ -156,29 +172,37 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
       bgColor: "#FEF3C7",
     },
     {
-      label: "Vencida",
-      value: defeatedCount,
-      icon: FiX,
-      color: "#b92110ff",
-      bgColor: "#fadad1ff",
-    },
-    {
       label: "Aprobadas",
       value: approvedCount,
       icon: FaCheck,
       color: "#8B5CF6",
       bgColor: "#EDE9FE",
     },
+    {
+      label: "Desaprobadas",
+      value: disapprovedCount,
+      icon: FaTimes,
+      color: "#EF4444",
+      bgColor: "#FEE2E2",
+    },
+    {
+      label: "Vencida",
+      value: defeatedCount,
+      icon: FiX,
+      color: "#b92110ff",
+      bgColor: "#fadad1ff",
+    },
   ];
 
-  //Filtros
+  // Filtros
   const statusFilters = [
     { key: "PUBLISHED", label: "Disponibles", emoji: <FaStar /> },
-    { key: "EXPIRED", label: "Vencidas", emoji: <FiXCircle /> },
     { key: "APPROVED", label: "Aprobadas", emoji: <FaCheck /> },
+    { key: "DISAPPROVED", label: "Desaprobadas", emoji: <FaTimes /> },
+    { key: "EXPIRED", label: "Vencidas", emoji: <FiXCircle /> },
   ];
 
-  //Acomodar con los filtros del get
+  // Materias
   const subjects: FilterOption[] = [
     { id: "ALL", name: "Todas las materias" },
     ...activityNotApproved
@@ -189,7 +213,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
       ),
   ];
 
-  //Iconos
+  // Iconos
   const icons = [
     FaPlay,
     FaGamepad,
@@ -205,7 +229,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     return <Icon />;
   };
 
-  //Dias
+  // Dias
   const getDaysUntilDue = (endDate: string) => {
     const due = new Date(endDate);
     const now = new Date();
@@ -218,7 +242,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     return `${diffDays} días`;
   };
 
-  //Status
+  // Status
   const getStatusConfig = (status: string) => {
     switch (status) {
       case "EXPIRED":
@@ -244,10 +268,17 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
         };
       case "APPROVED":
         return {
-          icon: FaStar,
+          icon: FaCheck,
           label: "Aprobada",
           buttonText: "Ver Resultados",
           buttonIcon: FaPlay,
+        };
+      case "DISAPPROVED":
+        return {
+          icon: FaTimes,
+          label: "Desaprobada",
+          buttonText: "Ver Detalles",
+          buttonIcon: FaTimes,
         };
       default:
         return {
@@ -261,7 +292,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     }
   };
 
-  //Colors
+  // Colors
   const colors = [
     "var(--color-stat-1)",
     "var(--color-stat-2)",
@@ -272,7 +303,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   const getRandomColor = () =>
     colors[Math.floor(Math.random() * colors.length)];
 
-  //Paginacion
+  // Paginacion
   const getSource = () =>
     activeFilter === "APPROVED"
       ? paginatedActivitiesApproved
@@ -302,6 +333,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
         filteredActivities,
         pendingCount,
         defeatedCount,
+        disapprovedCount,
         stats,
         statusFilters,
         subjects,
@@ -310,7 +342,6 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
         getDaysUntilDue,
         getRandomColor,
         getStatusConfig,
-        //paginacion
         paginationInfo,
       }}
     >

--- a/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextUI/ActivityStudentProviderUI.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, type ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import {
   FaPlay,
   FaCheck,
@@ -10,7 +10,7 @@ import {
   FaRocket,
   FaMedal,
   FaFlagCheckered,
-  FaTimes,
+  FaBan,
 } from "react-icons/fa";
 import { ActivityStudentContextUI } from "./ActivityStudentContextUI";
 import { useActivityStudent } from "../../../hooks/useActivityStudentAPI";
@@ -64,7 +64,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     useState<string>("PUBLISHED");
 
   // Fetch inicial para estadisticas
-  //Este get se realiza para poder obter las estadisticas, hasta que del back manden direcamente las estadisticas
+  // Este get se realiza para poder obtener las estadisticas, hasta que del back manden direcamente las estadisticas
   useEffect(() => {
     if (activityNotApproved.length <= 0) {
       getActivityApproved();
@@ -73,8 +73,8 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   }, []);
 
   const loadActivities = async () => {
-    let filters: string[] = [];
-    let filtersValues: string[] = [];
+    const filters: string[] = [];
+    const filtersValues: string[] = [];
 
     // status filter
     if (activeFilter === "EXPIRED" || activeFilter === "PUBLISHED") {
@@ -86,6 +86,9 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     if (activeFilter === "DISAPPROVED") {
       filters.push("disapproved");
       filtersValues.push("true");
+    } else if (activeFilter === "EXPIRED" || activeFilter === "PUBLISHED") {
+      filters.push("disapproved");
+      filtersValues.push("false");
     }
 
     // subject filter
@@ -139,16 +142,14 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   // Stats y contadores
   const getCounts = () => {
     const pending = activityNotApproved.filter(
-      (a) => a.status === "PUBLISHED"
+      (a) => a.status === "PUBLISHED" && a.remainingAttempts > 0
     ).length;
     const expired = activityNotApproved.filter(
-      (a) => a.status === "EXPIRED"
+      (a) => a.status === "EXPIRED" && a.remainingAttempts > 0
     ).length;
     const approved = activityApproved.filter(
       (a) => a.state === "APPROVED"
     ).length;
-
-    // Contador de desaprobadas - actividades sin intentos restantes
     const disapproved = activityNotApproved.filter(
       (a) => a.remainingAttempts === 0
     ).length;
@@ -181,8 +182,8 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     {
       label: "Desaprobadas",
       value: disapprovedCount,
-      icon: FaTimes,
-      color: "#EF4444",
+      icon: FaBan,
+      color: "#DC2626",
       bgColor: "#FEE2E2",
     },
     {
@@ -198,7 +199,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   const statusFilters = [
     { key: "PUBLISHED", label: "Disponibles", emoji: <FaStar /> },
     { key: "APPROVED", label: "Aprobadas", emoji: <FaCheck /> },
-    { key: "DISAPPROVED", label: "Desaprobadas", emoji: <FaTimes /> },
+    { key: "DESAPROBADAS", label: "Desaprobadas", emoji: <FaBan /> },
     { key: "EXPIRED", label: "Vencidas", emoji: <FiXCircle /> },
   ];
 
@@ -224,6 +225,7 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
     FaMedal,
     FaFlagCheckered,
   ];
+
   const getRandomIcon = () => {
     const Icon = icons[Math.floor(Math.random() * icons.length)];
     return <Icon />;
@@ -245,13 +247,6 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
   // Status
   const getStatusConfig = (status: string) => {
     switch (status) {
-      case "EXPIRED":
-        return {
-          icon: FiXCircle,
-          label: "Vencida",
-          buttonText: "Vencida",
-          buttonIcon: FiX,
-        };
       case "CREATED":
         return {
           icon: FaClock,
@@ -273,12 +268,12 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
           buttonText: "Ver Resultados",
           buttonIcon: FaPlay,
         };
-      case "DISAPPROVED":
+      case "EXPIRED":
         return {
-          icon: FaTimes,
-          label: "Desaprobada",
-          buttonText: "Ver Detalles",
-          buttonIcon: FaTimes,
+          icon: FiXCircle,
+          label: "Vencida",
+          buttonText: "Vencida",
+          buttonIcon: FiX,
         };
       default:
         return {
@@ -333,7 +328,6 @@ export const ActivityStudentProviderUI: React.FC<ProviderProps> = ({
         filteredActivities,
         pendingCount,
         defeatedCount,
-        disapprovedCount,
         stats,
         statusFilters,
         subjects,

--- a/src/student/types/Activity.type.ts
+++ b/src/student/types/Activity.type.ts
@@ -60,6 +60,7 @@ export interface ActivityUI {
   timeLabel?: string;
   rewardLabel?: string;
   reward?: string;
+  remainingAttempts: number;
   attemptsLabel: string;
   noAttempts: boolean;
   dueDateLabel?: string;


### PR DESCRIPTION
# Descripción
Se agregó la posibilidad de filtrar actividades desaprobadas

# Explicación
## Feature
Ahora el estudiante tiene una tab más en los filtros de Mis Actividades: Desaprobadas
<img width="619" height="137" alt="image" src="https://github.com/user-attachments/assets/f47a0c96-3e2d-4b56-92c2-d13ec6eb0897" />

Aquí el estudiante verá aquellas en las que utilizó todos sus intentos. Se refactorizó la forma de traer las actividades, ya que del lado del backend lo que se hizo fue agregar el filtro booleano "disapproved", no como un status como estaban las demás, por lo que ahora si busco disponibles también debemos aclarar que no busque por disapproved.

## Status
Como no es un status en sí en el backend, para configurar el label que aparece por encima del botón de acción tendría que refactorizar gran parte del módulo solo para que muestre desaprobado o algo así. Ahora se ve así:
<img width="1387" height="596" alt="image" src="https://github.com/user-attachments/assets/dc04e5f2-c31b-414d-8578-9e4233f51d78" />

El status que viene del backend es EXPIRED y por eso se ve así. Lo que podemos hacer es:
- Quitar el cosito ese que no sirve para mucho;
- El día que refactoricemos esto para usar custom hooks en vez de dejar todo en un provider se arregla;
- Pedimos que agreguen disapproved como status (viaje)
- Deuda técnica para siempre.

# Issue Relacionada
Closes #219 