### PR TITLE
[#247] feat: Historial de beneficios usados

### DIFF
--- a/src/benefit/components/benefitCardContent/BenefitCardContent.module.css
+++ b/src/benefit/components/benefitCardContent/BenefitCardContent.module.css
@@ -237,3 +237,30 @@
   font-weight: 600;
   color: white;
 }
+
+.usedAtSection {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background-color: #d1fae5;
+  border-radius: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.usedAtIcon {
+  color: #059669;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.usedAtText {
+  font-size: 0.875rem;
+  color: #065f46;
+  line-height: 1.4;
+}
+
+.usedAtText strong {
+  font-weight: 600;
+  color: #047857;
+}

--- a/src/benefit/components/benefitCardContent/BenefitCardContent.tsx
+++ b/src/benefit/components/benefitCardContent/BenefitCardContent.tsx
@@ -4,6 +4,7 @@ import {
   FaUsers,
   FaUser,
   FaCalendarAlt,
+  FaCheckCircle,
 } from "react-icons/fa";
 import Badge from "../../../shared/components/Badge/BadgeComponent";
 import Tooltip from "../../../shared/components/Tooltip/TooltipComponent";
@@ -57,6 +58,8 @@ const BenefitCardContent = ({
     categoryColor,
     isUseRequest,
     isPurchaseCard,
+    isUsedBenefit,
+    usedAt,
     studentName,
     purchaseState,
     purchaseId,
@@ -134,7 +137,53 @@ const BenefitCardContent = ({
     );
   }
 
-  // CASO 3: Vista normal (beneficio estándar)
+  // CASO 3: isUsedBenefit - Beneficio usado
+  if (isUsedBenefit) {
+    return (
+      <div className={styles.contentContainer}>
+        <div className={styles.benefitHeader}>
+          <div
+            className={styles.iconWrapper}
+            style={{ backgroundColor: iconColor }}
+          >
+            <IconComponent className={styles.benefitIcon} />
+          </div>
+          <div className={styles.benefitInfo}>
+            <h3 className={styles[`benefitName${styleSuffix}`]}>
+              {benefitName}
+            </h3>
+            <div className={styles.benefitMeta}>
+              {category && categoryColor && (
+                <Badge variant="custom" size="sm" customColor={categoryColor}>
+                  {category.label}
+                </Badge>
+              )}
+              {subjectName && subjectColor && (
+                <Badge variant="custom" size="sm" customColor={subjectColor}>
+                  {subjectName}
+                </Badge>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <p className={styles[`benefitDescription${styleSuffix}`]}>
+          {descriptionText}
+        </p>
+
+        {usedAt && (
+          <div className={styles.usedAtSection}>
+            <FaCheckCircle className={styles.usedAtIcon} />
+            <span className={styles.usedAtText}>
+              Fecha de uso: <strong>{formatBenefitDate(usedAt)}</strong>
+            </span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // CASO 4: Vista normal (beneficio estándar)
   return (
     <div className={styles.contentContainer}>
       <div className={styles.benefitHeader}>

--- a/src/benefit/components/benefitTableContent/BenefitTableContent.module.css
+++ b/src/benefit/components/benefitTableContent/BenefitTableContent.module.css
@@ -172,6 +172,31 @@
   gap: 0.5rem;
 }
 
+.usedDateSection {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: #d1fae5;
+  border-radius: 0.375rem;
+  width: fit-content;
+  margin: 0 auto;
+}
+
+.usedDateIcon {
+  color: #059669;
+  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
+.usedDateValue {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #065f46;
+  white-space: nowrap;
+}
+
 /* Responsive Design */
 @media (max-width: 1400px) {
   .tableCell {

--- a/src/benefit/components/benefitTableContent/BenefitTableContent.tsx
+++ b/src/benefit/components/benefitTableContent/BenefitTableContent.tsx
@@ -1,4 +1,10 @@
-import { FaCoins, FaUsers, FaUser, FaCalendarAlt } from "react-icons/fa";
+import {
+  FaCoins,
+  FaUsers,
+  FaUser,
+  FaCalendarAlt,
+  FaCheckCircle,
+} from "react-icons/fa";
 import Badge from "../../../shared/components/Badge/BadgeComponent";
 import Tooltip from "../../../shared/components/Tooltip/TooltipComponent";
 import type {
@@ -38,6 +44,8 @@ const BenefitTableContent: React.FC<BenefitTableContentProps> = ({
     subjectName,
     subjectColor,
     isUseRequest,
+    isUsedBenefit,
+    usedAt,
     studentName,
   } = useBenefitTableData({ benefit, variant });
 
@@ -67,6 +75,14 @@ const BenefitTableContent: React.FC<BenefitTableContentProps> = ({
               {isUseRequest ? (
                 <Badge variant="custom" size="sm" customColor={categoryColor}>
                   Solicitud de Uso
+                </Badge>
+              ) : isUsedBenefit ? (
+                <Badge
+                  variant="custom"
+                  size="sm"
+                  customColor={{ bg: "#d1fae5", text: "#065f46" }}
+                >
+                  Usado
                 </Badge>
               ) : (
                 category && (
@@ -104,7 +120,7 @@ const BenefitTableContent: React.FC<BenefitTableContentProps> = ({
       </td>
 
       {/* Estadísticas */}
-      {showStats && !isUseRequest && showStatsColumns && (
+      {showStats && !isUseRequest && !isUsedBenefit && showStatsColumns && (
         <>
           {/* Costo */}
           <td className={`${styles.tableCell} ${styles.centeredCell}`}>
@@ -191,16 +207,26 @@ const BenefitTableContent: React.FC<BenefitTableContentProps> = ({
         </>
       )}
 
-      {/* Fecha de Finalización */}
+      {/* Fecha de Finalización o Fecha de Uso */}
       {!isUseRequest && (
         <td className={`${styles.tableCell} ${styles.centeredCell}`}>
-          {"endAt" in benefit && benefit.endAt && (
-            <div className={styles.dateSection}>
-              <FaCalendarAlt className={styles.dateIcon} />
-              <span className={styles.dateValue}>
-                {formatBenefitDate(benefit.endAt)}
+          {isUsedBenefit && usedAt ? (
+            <div className={styles.usedDateSection}>
+              <FaCheckCircle className={styles.usedDateIcon} />
+              <span className={styles.usedDateValue}>
+                {formatBenefitDate(usedAt)}
               </span>
             </div>
+          ) : (
+            "endAt" in benefit &&
+            benefit.endAt && (
+              <div className={styles.dateSection}>
+                <FaCalendarAlt className={styles.dateIcon} />
+                <span className={styles.dateValue}>
+                  {formatBenefitDate(benefit.endAt)}
+                </span>
+              </div>
+            )
           )}
         </td>
       )}

--- a/src/benefit/constants/benefit.constants.ts
+++ b/src/benefit/constants/benefit.constants.ts
@@ -10,6 +10,7 @@ import {
   FaGift,
   FaShoppingBag,
   FaHandPaper,
+  FaCheckCircle,
 } from "react-icons/fa";
 import { FiXCircle } from "react-icons/fi";
 import type { Category, Color, Icon } from "../types/benefit.types";
@@ -127,6 +128,7 @@ export const BENEFIT_STATUS = {
   PURCHASED: "PURCHASED",
   USE_REQUESTED: "USE_REQUESTED",
   EXPIRED: "EXPIRED",
+  USED: "USED",
 } as const;
 
 export type BenefitStatus =
@@ -152,6 +154,11 @@ export const BENEFIT_STATUS_FILTERS = [
     key: BENEFIT_STATUS.EXPIRED,
     label: "Vencidos",
     icon: FiXCircle,
+  },
+  {
+    key: BENEFIT_STATUS.USED,
+    label: "Usados",
+    icon: FaCheckCircle,
   },
 ] as const;
 
@@ -233,6 +240,13 @@ export const BENEFIT_STATS_CONFIG = [
     icon: FaHandPaper,
     color: "#F59E0B",
     bgColor: "#FEF3C7",
+  },
+  {
+    key: "used",
+    label: "Usados",
+    icon: FaCheckCircle,
+    color: "#059669",
+    bgColor: "#D1FAE5",
   },
   {
     key: "expired",

--- a/src/benefit/hooks/useBenefitCardData.ts
+++ b/src/benefit/hooks/useBenefitCardData.ts
@@ -19,6 +19,7 @@ import {
   hasBenefitBasicProperties,
   isBenefitUseRequested,
   isBenefitPurchase,
+  isBenefitPurchasedUsed,
   getBenefitSubjectName,
 } from "../utils/benefit.utils";
 import { shouldShowBenefitStats } from "../utils/benefit.validation";
@@ -48,6 +49,42 @@ export const useBenefitCardData = ({
      *   - Si state === "USE_REQUESTED" -> Mostrar como UseRequest
      *   - Si state === "PURCHASED" o "USED" -> Mostrar como beneficio normal
      */
+
+    // CASO 0: Beneficio USADO
+    if (isBenefitPurchasedUsed(benefit)) {
+      const iconComponent = getIconByValue(benefit.icon);
+      const iconColor = getColorByValue(benefit.color) ?? "#94a3b8";
+      const category = getCategoryByValue(benefit.category);
+      const categoryColor = getCategoryColor(benefit.category);
+      const subjectName = benefit.subjectName;
+      const subjectColor = getSubjectColor(subjectName);
+
+      return {
+        IconComponent: iconComponent,
+        iconColor,
+        category,
+        styleSuffix: "Student",
+        purchaseLimit: null,
+        purchaseLimitPerStudent: null,
+        hasEndDate: false,
+        showStats: false,
+        benefitName: benefit.benefitName,
+        benefitCost: 0,
+        descriptionText: benefit.benefitDescription,
+        subjectName,
+        subjectColor,
+        categoryColor,
+        hasFullProperties: true,
+        hasBasicProperties: false,
+        isUseRequest: false,
+        isPurchaseCard: false,
+        isUsedBenefit: true,
+        usedAt: benefit.usedAt,
+        studentName: undefined,
+        purchaseState: benefit.state,
+        purchaseId: benefit.id,
+      };
+    }
 
     // CASO 1: Contexto de CANJES (isPurchase=true)
     if (
@@ -80,6 +117,8 @@ export const useBenefitCardData = ({
         hasBasicProperties: false,
         isUseRequest: false,
         isPurchaseCard: true,
+        isUsedBenefit: false,
+        usedAt: undefined,
         studentName: benefit.studentName,
         purchaseState: benefit.state,
         purchaseId: benefit.id,
@@ -116,6 +155,8 @@ export const useBenefitCardData = ({
         hasBasicProperties: false,
         isUseRequest: true,
         isPurchaseCard: false,
+        isUsedBenefit: false,
+        usedAt: undefined,
         studentName: benefit.studentName,
         purchaseState: benefit.state,
         purchaseId: benefit.id,
@@ -191,6 +232,8 @@ export const useBenefitCardData = ({
       hasBasicProperties,
       isUseRequest: false,
       isPurchaseCard: false,
+      isUsedBenefit: false,
+      usedAt: undefined,
       studentName: undefined,
       purchaseState: undefined,
       purchaseId: undefined,

--- a/src/benefit/hooks/useBenefitTableData.ts
+++ b/src/benefit/hooks/useBenefitTableData.ts
@@ -15,6 +15,7 @@ import {
   isFullBenefitResponse,
   hasBenefitBasicProperties,
   isBenefitUseRequested,
+  isBenefitPurchasedUsed,
   getBenefitSubjectName,
 } from "../utils/benefit.utils";
 import { shouldShowBenefitStats } from "../utils/benefit.validation";
@@ -27,9 +28,37 @@ export const useBenefitTableData = ({
   variant: BenefitVariant;
 }) => {
   return useMemo(() => {
+    // CASO 0: BENEFICIO USADO
+    if (isBenefitPurchasedUsed(benefit)) {
+      const iconComponent = getIconByValue(benefit.icon);
+      const iconColor = getColorByValue(benefit.color) ?? "#94a3b8";
+      const category = getCategoryByValue(benefit.category);
+      const categoryColor = getCategoryColor(benefit.category);
+      const subjectName = benefit.subjectName;
+      const subjectColor = getSubjectColor(subjectName);
+
+      return {
+        IconComponent: iconComponent,
+        iconColor,
+        category,
+        categoryName: category?.label || "",
+        categoryColor,
+        showStats: false,
+        benefitName: benefit.benefitName,
+        benefitDescription: benefit.benefitDescription,
+        benefitCost: 0,
+        subjectName,
+        subjectColor,
+        isUseRequest: false,
+        isUsedBenefit: true,
+        usedAt: benefit.usedAt,
+        studentName: undefined,
+      };
+    }
+
+    // CASO 1: USE REQUEST
     const isUseRequest = isBenefitUseRequested(benefit);
 
-    // Caso 1: USE REQUEST
     if (isUseRequest) {
       const iconComponent = getIconByValue(benefit.benefitIcon);
       const iconColor = getColorByValue(benefit.benefitColor) ?? "#94a3b8";
@@ -51,11 +80,13 @@ export const useBenefitTableData = ({
         subjectName,
         subjectColor,
         isUseRequest: true,
+        isUsedBenefit: false,
+        usedAt: undefined,
         studentName: benefit.studentName,
       };
     }
 
-    // Caso 2: BENEFICIO NORMAL
+    // CASO 2: BENEFICIO NORMAL
     const hasFullProperties = isFullBenefitResponse(benefit);
     const hasBasicProperties = hasBenefitBasicProperties(benefit);
 
@@ -99,6 +130,8 @@ export const useBenefitTableData = ({
       subjectName,
       subjectColor,
       isUseRequest: false,
+      isUsedBenefit: false,
+      usedAt: undefined,
       studentName: undefined,
     };
   }, [benefit, variant]);

--- a/src/benefit/types/benefit.types.ts
+++ b/src/benefit/types/benefit.types.ts
@@ -40,7 +40,8 @@ export type BenefitStudentState =
   | "AVAILABLE"
   | "PURCHASED"
   | "USE_REQUESTED"
-  | "EXPIRED";
+  | "EXPIRED"
+  | "USED";
 
 export type BenefitTeacherState = "PUBLISHED" | "EXPIRED";
 
@@ -94,6 +95,20 @@ export interface BenefitPurchaseSimpleResponse {
   usedAt?: string;
 }
 
+export interface BenefitPurchasedUsedResponse {
+  id: number;
+  state: "USED";
+  benefitId: number;
+  benefitName: string;
+  benefitDescription: string;
+  category: Category;
+  color: Color;
+  icon: Icon;
+  subjectId: number;
+  subjectName: string;
+  usedAt?: string;
+}
+
 export interface BenefitStudentResponseInterface {
   id: number;
   name: string;
@@ -130,7 +145,8 @@ export type AnyBenefit =
   | BenefitResponseInterface
   | BenefitStudentResponseInterface
   | CreateBenefitInterface
-  | BenefitPurchaseSimpleResponse;
+  | BenefitPurchaseSimpleResponse
+  | BenefitPurchasedUsedResponse;
 
 export type TeacherBenefitType =
   | BenefitResponseInterface
@@ -162,6 +178,13 @@ export interface PaginatedBenefitUseRequestedResponseInterface {
 
 export interface PaginatedBenefitPurchaseSimpleResponse {
   data: PaginatedData<BenefitPurchaseSimpleResponse>;
+  message: string;
+  errors: any;
+  timestamp: string;
+}
+
+export interface PaginatedBenefitPurchasedUsedResponse {
+  data: PaginatedData<BenefitPurchasedUsedResponse>;
   message: string;
   errors: any;
   timestamp: string;

--- a/src/benefit/utils/benefit.utils.ts
+++ b/src/benefit/utils/benefit.utils.ts
@@ -3,6 +3,7 @@ import { FaGift } from "react-icons/fa";
 import type {
   BenefitResponseInterface,
   BenefitStudentResponseInterface,
+  BenefitPurchasedUsedResponse,
   CreateBenefitInterface,
   AnyBenefit,
   TeacherBenefitType,
@@ -88,6 +89,20 @@ export const isBenefitPurchase = (
     (benefit.state === "PURCHASED" ||
       benefit.state === "USE_REQUESTED" ||
       benefit.state === "USED")
+  );
+};
+
+export const isBenefitPurchasedUsed = (
+  benefit: any
+): benefit is BenefitPurchasedUsedResponse => {
+  return (
+    "id" in benefit &&
+    "state" in benefit &&
+    benefit.state === "USED" &&
+    "benefitId" in benefit &&
+    "benefitName" in benefit &&
+    "usedAt" in benefit &&
+    !("name" in benefit)
   );
 };
 

--- a/src/student/components/studentBenefits/benefitStudentCard/BenefitStudentCard.tsx
+++ b/src/student/components/studentBenefits/benefitStudentCard/BenefitStudentCard.tsx
@@ -114,6 +114,18 @@ const BenefitStudentCard: React.FC<BenefitStudentCardProps> = ({
             {buttonExpired}
           </Tooltip>
         );
+      case BENEFIT_STATUS.USED:
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className={`${styles.actionButton} ${styles.disabledButton}`}
+            disabled
+          >
+            <FaCheckCircle className={styles.buttonIcon} />
+            Usado
+          </Button>
+        );
       default:
         return null;
     }

--- a/src/student/components/studentBenefits/benefitStudentList/BenefitStudentList.tsx
+++ b/src/student/components/studentBenefits/benefitStudentList/BenefitStudentList.tsx
@@ -36,7 +36,6 @@ const BenefitStudentList: React.FC<BenefitStudentListProps> = ({
     return (
       <div className={styles.loadingContainer}>
         <LoadingSpinner />
-        <p className={styles.loadingText}>Cargando beneficios...</p>
       </div>
     );
   }

--- a/src/student/components/studentBenefits/benefitStudentTable/BenefitStudentTable.tsx
+++ b/src/student/components/studentBenefits/benefitStudentTable/BenefitStudentTable.tsx
@@ -1,7 +1,10 @@
 import { motion } from "framer-motion";
 import { FaShoppingCart, FaCheckCircle, FaHourglassHalf } from "react-icons/fa";
 import { FiXCircle } from "react-icons/fi";
-import type { BenefitStudentResponseInterface } from "../../../../benefit/types/benefit.types";
+import type {
+  BenefitStudentResponseInterface,
+  BenefitPurchasedUsedResponse,
+} from "../../../../benefit/types/benefit.types";
 import Button from "../../../../shared/components/Button/ButtonComponent";
 import Tooltip from "../../../../shared/components/Tooltip/TooltipComponent";
 import BenefitTableContent from "../../../../benefit/components/benefitTableContent/BenefitTableContent";
@@ -10,11 +13,12 @@ import {
   validateBenefitPurchase,
   shouldShowBenefitStats,
 } from "../../../../benefit/utils/benefit.validation";
+import { isBenefitPurchasedUsed } from "../../../../benefit/utils/benefit.utils";
 import { useCurrentStudent } from "../../../hooks/useCurrentStudent";
 import styles from "./BenefitStudentTable.module.css";
 
 interface BenefitStudentTableProps {
-  benefits: BenefitStudentResponseInterface[];
+  benefits: (BenefitStudentResponseInterface | BenefitPurchasedUsedResponse)[];
   onPurchase: (benefitId: number, benefitName: string, cost: number) => void;
   onRequestUse: (benefitId: number, benefitName: string) => void;
 }
@@ -34,10 +38,28 @@ const BenefitStudentTable: React.FC<BenefitStudentTableProps> = ({
     onRequestUse(benefit.id, benefit.name);
   };
 
-  const getActionButton = (benefit: BenefitStudentResponseInterface) => {
-    switch (benefit.state) {
+  const getActionButton = (
+    benefit: BenefitStudentResponseInterface | BenefitPurchasedUsedResponse
+  ) => {
+    if (isBenefitPurchasedUsed(benefit)) {
+      return (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={`${styles.actionButton} ${styles.disabledButton}`}
+          disabled
+        >
+          <FaCheckCircle className={styles.buttonIcon} />
+          Usado
+        </Button>
+      );
+    }
+
+    const studentBenefit = benefit as BenefitStudentResponseInterface;
+
+    switch (studentBenefit.state) {
       case BENEFIT_STATUS.AVAILABLE: {
-        const validation = validateBenefitPurchase(benefit, wallet);
+        const validation = validateBenefitPurchase(studentBenefit, wallet);
         const cannotPurchase = !validation.canPurchase;
 
         const button = (
@@ -49,7 +71,7 @@ const BenefitStudentTable: React.FC<BenefitStudentTableProps> = ({
             }`}
             disabled={cannotPurchase}
             onClick={
-              !cannotPurchase ? () => handlePurchase(benefit) : undefined
+              !cannotPurchase ? () => handlePurchase(studentBenefit) : undefined
             }
           >
             <FaShoppingCart className={styles.buttonIcon} />
@@ -70,13 +92,14 @@ const BenefitStudentTable: React.FC<BenefitStudentTableProps> = ({
 
         return button;
       }
+
       case BENEFIT_STATUS.PURCHASED:
         return (
           <Button
             variant="secondary"
             size="sm"
             className={styles.actionButton}
-            onClick={() => handleRequestUse(benefit)}
+            onClick={() => handleRequestUse(studentBenefit)}
           >
             <FaCheckCircle className={styles.buttonIcon} />
             Usar
@@ -114,15 +137,33 @@ const BenefitStudentTable: React.FC<BenefitStudentTableProps> = ({
             {buttonExpired}
           </Tooltip>
         );
+
+      case BENEFIT_STATUS.USED:
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className={`${styles.actionButton} ${styles.disabledButton}`}
+            disabled
+          >
+            <FaCheckCircle className={styles.buttonIcon} />
+            Usado
+          </Button>
+        );
+
       default:
         return null;
     }
   };
 
   const showStatsColumns =
-    benefits.length > 0 && shouldShowBenefitStats(benefits[0]);
+    benefits.length > 0 &&
+    !isBenefitPurchasedUsed(benefits[0]) &&
+    shouldShowBenefitStats(benefits[0] as BenefitStudentResponseInterface);
 
-  const renderBenefitRow = (benefit: BenefitStudentResponseInterface) => {
+  const renderBenefitRow = (
+    benefit: BenefitStudentResponseInterface | BenefitPurchasedUsedResponse
+  ) => {
     return (
       <motion.tr
         key={benefit.id}
@@ -141,44 +182,51 @@ const BenefitStudentTable: React.FC<BenefitStudentTableProps> = ({
     );
   };
 
+  const renderTableHeaders = () => {
+    const isUsedBenefitList =
+      benefits.length > 0 && isBenefitPurchasedUsed(benefits[0]);
+
+    return (
+      <tr>
+        <th className={styles.tableHeader} style={{ width: "20%" }}>
+          Beneficio
+        </th>
+        <th
+          className={styles.tableHeader}
+          style={{ width: showStatsColumns ? "25%" : "35%" }}
+        >
+          Descripción
+        </th>
+        {showStatsColumns && (
+          <>
+            <th className={styles.tableHeader} style={{ width: "10%" }}>
+              Costo
+            </th>
+            <th className={styles.tableHeader} style={{ width: "10%" }}>
+              Disponibles
+            </th>
+            <th className={styles.tableHeader} style={{ width: "10%" }}>
+              Mis Usos
+            </th>
+          </>
+        )}
+        <th
+          className={styles.tableHeader}
+          style={{ width: showStatsColumns ? "15%" : "20%" }}
+        >
+          {isUsedBenefitList ? "Fecha de uso" : "Fecha de vencimiento"}
+        </th>
+        <th className={styles.tableHeader} style={{ width: "10%" }}>
+          Acción
+        </th>
+      </tr>
+    );
+  };
+
   return (
     <div className={styles.tableContainer}>
       <table className={styles.table}>
-        <thead className={styles.tableHead}>
-          <tr>
-            <th className={styles.tableHeader} style={{ width: "20%" }}>
-              Beneficio
-            </th>
-            <th
-              className={styles.tableHeader}
-              style={{ width: showStatsColumns ? "25%" : "35%" }}
-            >
-              Descripción
-            </th>
-            {showStatsColumns && (
-              <>
-                <th className={styles.tableHeader} style={{ width: "10%" }}>
-                  Costo
-                </th>
-                <th className={styles.tableHeader} style={{ width: "10%" }}>
-                  Disponibles
-                </th>
-                <th className={styles.tableHeader} style={{ width: "10%" }}>
-                  Mis Usos
-                </th>
-              </>
-            )}
-            <th
-              className={styles.tableHeader}
-              style={{ width: showStatsColumns ? "15%" : "20%" }}
-            >
-              Finaliza
-            </th>
-            <th className={styles.tableHeader} style={{ width: "10%" }}>
-              Acción
-            </th>
-          </tr>
-        </thead>
+        <thead className={styles.tableHead}>{renderTableHeaders()}</thead>
         <tbody className={styles.tableBody}>
           {benefits.map(renderBenefitRow)}
         </tbody>

--- a/src/student/context/benefitStudentContext/BenefitStudentContext.type.ts
+++ b/src/student/context/benefitStudentContext/BenefitStudentContext.type.ts
@@ -1,5 +1,6 @@
 import type {
   BenefitStudentResponseInterface,
+  BenefitPurchasedUsedResponse,
   BenefitStatsResponse,
 } from "../../../benefit/types/benefit.types";
 import type {
@@ -10,11 +11,15 @@ import type {
 export interface BenefitStudentContextType {
   // Estados principales
   loading: boolean;
-  paginatedBenefits: PaginatedData<BenefitStudentResponseInterface> | null;
+  paginatedBenefits:
+    | PaginatedData<BenefitStudentResponseInterface>
+    | PaginatedData<BenefitPurchasedUsedResponse>
+    | null;
   benefitStats: BenefitStatsResponse | null;
 
   // Funciones Principales
   getPaginatedBenefitStudent: (params: GetPaginated) => Promise<void>;
+  getPaginatedUsedBenefitStudent: (params: GetPaginated) => Promise<void>;
   purchaseBenefitStudent: (benefitId: number) => Promise<void>;
   requestUseBenefitStudent: (benefitId: number) => Promise<void>;
   getBenefitStudentStats: () => Promise<void>;

--- a/src/student/context/benefitStudentContext/BenefitStudentProvider.tsx
+++ b/src/student/context/benefitStudentContext/BenefitStudentProvider.tsx
@@ -4,6 +4,7 @@ import type { BenefitStudentContextType } from "./BenefitStudentContext.type";
 import { BenefitStudentService } from "../../services/benefit/BenefitStudentService";
 import type {
   BenefitStudentResponseInterface,
+  BenefitPurchasedUsedResponse,
   BenefitStatsResponse,
 } from "../../../benefit/types/benefit.types";
 import type {
@@ -21,8 +22,11 @@ export const BenefitStudentProvider = ({
 
   // Estados Generales
   const [loading, setLoading] = useState<boolean>(false);
-  const [paginatedBenefits, setPaginatedBenefits] =
-    useState<PaginatedData<BenefitStudentResponseInterface> | null>(null);
+  const [paginatedBenefits, setPaginatedBenefits] = useState<
+    | PaginatedData<BenefitStudentResponseInterface>
+    | PaginatedData<BenefitPurchasedUsedResponse>
+    | null
+  >(null);
   const [benefitStats, setBenefitStats] = useState<BenefitStatsResponse | null>(
     null
   );
@@ -37,6 +41,25 @@ export const BenefitStudentProvider = ({
         setPaginatedBenefits(response.data);
       } catch (error) {
         handleApiError(error, "Error al obtener los beneficios del estudiante");
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const getPaginatedUsedBenefitStudent = useCallback(
+    async (params: GetPaginated): Promise<void> => {
+      setLoading(true);
+      try {
+        const response =
+          await BenefitStudentService.getPaginatedUsedBenefitStudentApi(params);
+        setPaginatedBenefits(response.data);
+      } catch (error) {
+        handleApiError(
+          error,
+          "Error al obtener los beneficios usados del estudiante"
+        );
       } finally {
         setLoading(false);
       }
@@ -94,6 +117,7 @@ export const BenefitStudentProvider = ({
 
     // Funciones Principales
     getPaginatedBenefitStudent,
+    getPaginatedUsedBenefitStudent,
     getBenefitStudentStats,
     purchaseBenefitStudent,
     requestUseBenefitStudent,

--- a/src/student/hooks/benefits/benefitList/useBenefitStudentData.ts
+++ b/src/student/hooks/benefits/benefitList/useBenefitStudentData.ts
@@ -14,6 +14,7 @@ export const useBenefitStudentData = () => {
     loading,
     paginatedBenefits,
     getPaginatedBenefitStudent,
+    getPaginatedUsedBenefitStudent,
     getBenefitStudentStats,
   } = useBenefitStudent();
 
@@ -42,6 +43,18 @@ export const useBenefitStudentData = () => {
     const filters: string[] = [];
     const filtersValues: string[] = [];
 
+    // Caso especial: filtro "Usados"
+    if (activeFilter === "USED") {
+      await getPaginatedUsedBenefitStudent({
+        ...paginationParams,
+        ...(selectedSubject &&
+          selectedSubject.id !== "ALL" && { subjectId: selectedSubject.id }),
+        ...(selectedCategory &&
+          selectedCategory !== "ALL" && { category: selectedCategory }),
+      });
+      return;
+    }
+
     // Estado (benefit.state)
     filters.push("state");
     filtersValues.push(activeFilter);
@@ -69,6 +82,7 @@ export const useBenefitStudentData = () => {
     selectedSubject,
     selectedCategory,
     getPaginatedBenefitStudent,
+    getPaginatedUsedBenefitStudent,
   ]);
 
   /**

--- a/src/student/services/benefit/BenefitStudentService.ts
+++ b/src/student/services/benefit/BenefitStudentService.ts
@@ -2,6 +2,7 @@ import { BaseBenefitService } from "../../../benefit/services/BaseBenefitService
 import type {
   BenefitStatsApiResponse,
   PaginatedBenefitStudentResponseInterface,
+  PaginatedBenefitPurchasedUsedResponse,
 } from "../../../benefit/types/benefit.types";
 import type { GetPaginated } from "../../../shared/types/PaginacionType";
 import api from "../../../shared/utils/api";
@@ -11,6 +12,12 @@ export const BenefitStudentService = {
   getPaginatedBenefitStudentApi: (params: GetPaginated) =>
     BaseBenefitService.getPaginated<PaginatedBenefitStudentResponseInterface>(
       urls.PaginatedBenefitStudent,
+      params
+    ),
+
+  getPaginatedUsedBenefitStudentApi: (params: GetPaginated) =>
+    BaseBenefitService.getPaginated<PaginatedBenefitPurchasedUsedResponse>(
+      urls.PaginatedUsedBenefitStudent,
       params
     ),
 

--- a/src/student/services/urls.ts
+++ b/src/student/services/urls.ts
@@ -15,6 +15,7 @@ export const urls = {
 
   // Benefits
   PaginatedBenefitStudent: "/benefits/student/paginated",
+  PaginatedUsedBenefitStudent: "/benefits/student/used/paginated",
   BenefitStudentStats: "/benefits/student/count",
   PurchaseBenefitStudent: "/benefits/student/purchase",
   RequestUseBenefitStudent: (benefitId: number) =>

--- a/src/teacher/constants/animations/benefitTeacher.animations.ts
+++ b/src/teacher/constants/animations/benefitTeacher.animations.ts
@@ -30,3 +30,8 @@ export const benefitsListItemVariants: Variants = {
     scale: 1.02,
   },
 };
+
+export const tableRowVariants: Variants = {
+  hidden: { opacity: 0, y: 10 },
+  visible: { opacity: 1, y: 0 },
+};


### PR DESCRIPTION
# Descripción
Agregar historial de beneficios para que los estudiantes puedan ver qué beneficios fueron usados (aceptados por el docente)

# Explicación
Se agregó una tab más al filtrado de beneficios llamado "Usados" que funciona como un historial de beneficios.

## Modo card (grid)
<img width="926" height="882" alt="image" src="https://github.com/user-attachments/assets/7fc7fc83-f8aa-4e31-a304-061c3bef65b5" />

## Modo table
<img width="923" height="828" alt="image" src="https://github.com/user-attachments/assets/e318e1dc-b8e9-473e-a829-cf9eca317817" />

# Consideraciones
Se podría agregar algo que muestre que no tuvo fecha de finalización, pero como según entiendo siempre va a existir esa fecha de ahora en más, y quiero laburar lo menos posible, no lo hice.

# Issue relacionada
Closes #247 

