### PR TITLE
[#255[ fix: Beneficios paginados en canjes

### DIFF
--- a/src/shared/components/LoadingSpinner/LoadingSpinnerComponent.tsx
+++ b/src/shared/components/LoadingSpinner/LoadingSpinnerComponent.tsx
@@ -6,17 +6,23 @@ interface LoadingSpinnerProps {
   size?: "sm" | "md" | "lg";
   text?: string;
   overlay?: boolean;
+  color?: string;
 }
 
 const LoadingSpinnerComponent: React.FC<LoadingSpinnerProps> = ({
   size = "md",
   text = "Cargando...",
   overlay = false,
+  color = "#3b82f6",
 }) => {
   const spinnerContent = (
     <div className={`${styles.container} ${styles[size]}`}>
       <motion.div
         className={styles.spinner}
+        style={{
+          borderTopColor: color,
+          borderLeftColor: color,
+        }}
         animate={{ rotate: 360 }}
         transition={{
           duration: 1,

--- a/src/teacher/components/benefitsView/benefitCardComponent/benefitCard/BenefitCard.tsx
+++ b/src/teacher/components/benefitsView/benefitCardComponent/benefitCard/BenefitCard.tsx
@@ -47,7 +47,7 @@ const BenefitCard: React.FC<BenefitCardProps> = ({
               variant="secondary"
               size="sm"
               className={styles.viewRedemptionsButtonUR}
-              onClick={() => actions.onViewPurchases(actualBenefitId)}
+              onClick={() => actions.onViewPurchases(benefit, actualBenefitId)}
             >
               <FaEye className={styles.actionIcon} />
               Ver otros canjes
@@ -59,7 +59,7 @@ const BenefitCard: React.FC<BenefitCardProps> = ({
               variant="secondary"
               size="sm"
               className={styles.viewRedemptionsButton}
-              onClick={() => actions.onViewPurchases(benefitId)}
+              onClick={() => actions.onViewPurchases(benefit, actualBenefitId)}
             >
               <FaEye className={styles.actionIcon} />
               Ver Canjes

--- a/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseCard/BenefitPurchaseCard.tsx
+++ b/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseCard/BenefitPurchaseCard.tsx
@@ -3,8 +3,9 @@ import { FaCheck, FaCheckCircle, FaShoppingCart } from "react-icons/fa";
 import Card from "../../../../../shared/components/Card/CardComponent";
 import Button from "../../../../../shared/components/Button/ButtonComponent";
 import Tooltip from "../../../../../shared/components/Tooltip/TooltipComponent";
-import BenefitCardContent from "../../../../../benefit/components/benefitCardContent/BenefitCardContent";
 import type { BenefitPurchaseSimpleResponse } from "../../../../../benefit/types/benefit.types";
+import BenefitCardContent from "../../../../../benefit/components/benefitCardContent/BenefitCardContent";
+import { benefitCardVariants } from "../../../../constants/animations/benefitTeacher.animations";
 import { formatPurchaseDate } from "../../../../utils/benefitPurchaseCard.utils";
 import styles from "./BenefitPurchaseCard.module.css";
 
@@ -19,11 +20,6 @@ const BenefitPurchaseCard: React.FC<BenefitPurchaseCardProps> = ({
   onAcceptUse,
   loading,
 }) => {
-  const cardVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { opacity: 1, y: 0 },
-  };
-
   const getActionButtons = () => {
     // CASO 1: Solicitud de uso pendiente (USE_REQUESTED)
     if (purchase.state === "USE_REQUESTED") {
@@ -96,7 +92,7 @@ const BenefitPurchaseCard: React.FC<BenefitPurchaseCardProps> = ({
 
   return (
     <motion.div
-      variants={cardVariants}
+      variants={benefitCardVariants}
       initial="hidden"
       animate="visible"
       whileHover={{

--- a/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseInfo/BenefitPurchaseInfo.tsx
+++ b/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseInfo/BenefitPurchaseInfo.tsx
@@ -1,42 +1,54 @@
 import { FaBook } from "react-icons/fa";
 import Card from "../../../../../shared/components/Card/CardComponent";
 import Badge from "../../../../../shared/components/Badge/BadgeComponent";
+import type { BenefitResponseInterface } from "../../../../../benefit/types/benefit.types";
 import { getSubjectColor } from "../../../../../shared/constants/subject.constants";
 import {
   getIconByValue,
   getColorByValue,
+  getCategoryColor,
 } from "../../../../../benefit/utils/benefit.utils";
-import type { BenefitPurchaseSimpleResponse } from "../../../../../benefit/types/benefit.types";
 import styles from "./BenefitPurchaseInfo.module.css";
 
 interface BenefitInfoProps {
-  purchase: BenefitPurchaseSimpleResponse | null;
+  benefit: BenefitResponseInterface | null;
 }
 
-const BenefitPurchaseInfo: React.FC<BenefitInfoProps> = ({ purchase }) => {
-  if (!purchase) {
+const BenefitPurchaseInfo: React.FC<BenefitInfoProps> = ({ benefit }) => {
+  if (!benefit) {
     return null;
   }
 
-  const subjectColor = getSubjectColor(purchase.subjectName);
-  const BenefitIcon = getIconByValue(purchase.benefitIcon);
-  const benefitColor = getColorByValue(purchase.benefitColor) ?? "#667eea";
+  const name = benefit.name;
+  const subjectName = benefit.subjectDto.name || "Sin materia";
+  const categoryName = benefit.category || "General";
+  const benefitIcon = benefit.icon || "default";
+  const benefitColor = benefit.color || "#667eea";
+
+  const subjectColor = getSubjectColor(subjectName);
+  const categoryColor = getCategoryColor(categoryName);
+  const BenefitIcon = getIconByValue(benefitIcon);
+  const color = getColorByValue(benefitColor) ?? "#667eea";
 
   return (
     <Card className={styles.benefitInfoCard}>
       <div className={styles.infoHeader}>
         <div
           className={styles.iconContainer}
-          style={{ backgroundColor: benefitColor }}
+          style={{ backgroundColor: color }}
         >
           <BenefitIcon className={styles.benefitIcon} />
         </div>
         <div className={styles.infoContent}>
-          <h3 className={styles.benefitName}>{purchase.benefitName}</h3>
+          <h3 className={styles.benefitName}>{name}</h3>
           <div className={styles.badges}>
+            <Badge variant="custom" size="sm" customColor={categoryColor}>
+              <FaBook className={styles.badgeIcon} />
+              {categoryName}
+            </Badge>
             <Badge variant="custom" size="sm" customColor={subjectColor}>
               <FaBook className={styles.badgeIcon} />
-              {purchase.subjectName}
+              {subjectName}
             </Badge>
           </div>
         </div>

--- a/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseList/BenefitPurchaseList.module.css
+++ b/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseList/BenefitPurchaseList.module.css
@@ -16,9 +16,9 @@
 }
 
 .noResultsIcon {
+  color: var(--color-secondary);
   font-size: 4rem;
-  color: #d1d5db;
-  margin-bottom: 1.5rem;
+  opacity: 0.5;
 }
 
 .noResultsTitle {

--- a/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseList/BenefitPurchaseList.tsx
+++ b/src/teacher/components/benefitsView/benefitPurchases/benefitPurchaseList/BenefitPurchaseList.tsx
@@ -1,8 +1,10 @@
 import { motion } from "framer-motion";
 import { FaShoppingCart } from "react-icons/fa";
+import { EmptyStateComponent } from "../../../../../shared/components/EmptyState/EmptyStateComponent";
 import PaginateComponent from "../../../../../shared/components/PaginateComponent/PaginateComponent";
 import BenefitPurchaseCard from "../benefitPurchaseCard/BenefitPurchaseCard";
 import type { BenefitPurchaseSimpleResponse } from "../../../../../benefit/types/benefit.types";
+import { benefitItemVariants } from "../../../../constants/animations/benefitTeacher.animations";
 import styles from "./BenefitPurchaseList.module.css";
 
 interface BenefitPurchaseListProps {
@@ -25,18 +27,13 @@ const BenefitPurchaseList: React.FC<BenefitPurchaseListProps> = ({
   onAcceptUse,
   loading,
 }) => {
-  const itemVariants = {
-    hidden: { y: 20, opacity: 0 },
-    visible: { y: 0, opacity: 1 },
-  };
-
   return (
     <PaginateComponent pagination={paginationInfo || undefined}>
       <div className={styles.purchasesList}>
         {purchases.map((purchase) => (
           <motion.div
             key={purchase.id}
-            variants={itemVariants}
+            variants={benefitItemVariants}
             whileHover={{ y: -5 }}
             transition={{ type: "spring", stiffness: 300 }}
           >
@@ -51,14 +48,12 @@ const BenefitPurchaseList: React.FC<BenefitPurchaseListProps> = ({
 
       {/* Sin resultados */}
       {purchases.length === 0 && !loading && (
-        <motion.div variants={itemVariants} className={styles.noResults}>
-          <FaShoppingCart className={styles.noResultsIcon} />
-          <h3 className={styles.noResultsTitle}>No se encontraron canjes</h3>
-          <p className={styles.noResultsText}>
-            No hay canjes registrados para este beneficio con los filtros
-            seleccionados.
-          </p>
-        </motion.div>
+        <EmptyStateComponent
+          title="No se encontraron canjes"
+          message="No hay canjes registrados para este beneficio con los filtros
+            seleccionados."
+          icon={<FaShoppingCart className={styles.noResultsIcon} />}
+        />
       )}
     </PaginateComponent>
   );

--- a/src/teacher/components/benefitsView/benefitPurchases/benefitPurchasesFilters/BenefitPurchaseFilters.tsx
+++ b/src/teacher/components/benefitsView/benefitPurchases/benefitPurchasesFilters/BenefitPurchaseFilters.tsx
@@ -6,6 +6,7 @@ import {
   BENEFIT_PURCHASE_STATUS_FILTERS,
   type BenefitPurchaseStatus,
 } from "../../../../../benefit/constants/benefitPurchase.constants";
+import { benefitItemVariants } from "../../../../constants/animations/benefitTeacher.animations";
 import styles from "./BenefitPurchaseFilters.module.css";
 
 interface BenefitPurchasesFiltersProps {
@@ -17,13 +18,11 @@ const BenefitPurchaseFilters: React.FC<BenefitPurchasesFiltersProps> = ({
   activeFilter,
   onFilterChange,
 }) => {
-  const itemVariants = {
-    hidden: { y: 20, opacity: 0 },
-    visible: { y: 0, opacity: 1 },
-  };
-
   return (
-    <motion.div variants={itemVariants} className={styles.filtersContainer}>
+    <motion.div
+      variants={benefitItemVariants}
+      className={styles.filtersContainer}
+    >
       <Card className={styles.filtersCard}>
         <div className={styles.filtersHeader}>
           <div className={styles.headerLeft}>

--- a/src/teacher/components/benefitsView/benefitTable/BenefitTable.tsx
+++ b/src/teacher/components/benefitsView/benefitTable/BenefitTable.tsx
@@ -72,7 +72,9 @@ const BenefitTable: React.FC<BenefitTableProps> = ({
                   variant="ghost"
                   size="sm"
                   className={`${styles.actionButton} ${styles.viewButton}`}
-                  onClick={() => actions.onViewPurchases(actualBenefitId)}
+                  onClick={() =>
+                    actions.onViewPurchases(benefit, actualBenefitId)
+                  }
                 >
                   <FaEye /> Canjes
                 </Button>
@@ -83,7 +85,7 @@ const BenefitTable: React.FC<BenefitTableProps> = ({
                   variant="ghost"
                   size="sm"
                   className={`${styles.actionButton} ${styles.viewButton}`}
-                  onClick={() => actions.onViewPurchases(benefitId)}
+                  onClick={() => actions.onViewPurchases(benefit, benefitId)}
                 >
                   <FaEye /> Ver Canjes
                 </Button>

--- a/src/teacher/constants/animations/benefitTeacher.animations.ts
+++ b/src/teacher/constants/animations/benefitTeacher.animations.ts
@@ -10,9 +10,25 @@ export const benefitListContainerVariants: Variants = {
   },
 };
 
+export const benefitPurchasesContainerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+      delayChildren: 0.05,
+    },
+  },
+};
+
 export const benefitItemVariants: Variants = {
   hidden: { y: 20, opacity: 0 },
   visible: { y: 0, opacity: 1 },
+};
+
+export const benefitCardVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
 };
 
 export const benefitsListItemVariants: Variants = {

--- a/src/teacher/contexts/benefitsAPIContext/BenefitAPIContext.type.ts
+++ b/src/teacher/contexts/benefitsAPIContext/BenefitAPIContext.type.ts
@@ -13,6 +13,7 @@ export interface BenefitAPIContextType {
   // Estados generales
   loading: boolean;
   benefits: BenefitResponseInterface[];
+  selectedBenefit: BenefitResponseInterface | null;
   benefitPurchases: BenefitPurchaseSimpleResponse[];
   paginatedBenefits: PaginatedData<BenefitResponseInterface> | null;
   paginatedBenefitsUseRequested: PaginatedData<BenefitUseRequestedResponseInterface> | null;
@@ -34,6 +35,7 @@ export interface BenefitAPIContextType {
   deleteBenefit: (benefitId: number) => Promise<void>;
 
   // Funciones auxiliares
+  setSelectedBenefit: (benefit: BenefitResponseInterface | null) => void;
   refreshBenefitsAfterDeletion: () => Promise<void>;
   refreshBenefitsAfterAcceptance: () => Promise<void>;
 }

--- a/src/teacher/contexts/benefitsAPIContext/BenefitAPIProvider.tsx
+++ b/src/teacher/contexts/benefitsAPIContext/BenefitAPIProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from "react";
+import { useEffect, useCallback, useState, type ReactNode } from "react";
 import { BenefitTeacherService } from "../../services/benefit/BenefitTeacherService";
 import { BenefitAPIContext } from "./BenefitAPIContext";
 import type { BenefitAPIContextType } from "./BenefitAPIContext.type";
@@ -19,6 +19,8 @@ interface BenefitProviderProps {
   children: ReactNode;
 }
 
+const SELECTED_BENEFIT_KEY = "teacher_selected_benefit";
+
 export const BenefitAPIProvider: React.FC<BenefitProviderProps> = ({
   children,
 }) => {
@@ -28,6 +30,16 @@ export const BenefitAPIProvider: React.FC<BenefitProviderProps> = ({
   // Estados generales
   const [loading, setLoading] = useState<boolean>(false);
   const [benefits, setBenefits] = useState<BenefitResponseInterface[]>([]);
+  const [selectedBenefit, setSelectedBenefit] =
+    useState<BenefitResponseInterface | null>(() => {
+      try {
+        const stored = localStorage.getItem(SELECTED_BENEFIT_KEY);
+        return stored ? JSON.parse(stored) : null;
+      } catch (error) {
+        console.warn("Error al leer selectedBenefit de localStorage", error);
+        return null;
+      }
+    });
   const [benefitPurchases, setBenefitPurchases] = useState<
     BenefitPurchaseSimpleResponse[]
   >([]);
@@ -37,6 +49,24 @@ export const BenefitAPIProvider: React.FC<BenefitProviderProps> = ({
     useState<PaginatedData<BenefitUseRequestedResponseInterface> | null>(null);
   const [paginatedBenefitsPurchases, setPaginatedBenefitsPurchases] =
     useState<PaginatedData<BenefitPurchaseSimpleResponse> | null>(null);
+
+  useEffect(() => {
+    if (selectedBenefit === null) {
+      localStorage.removeItem(SELECTED_BENEFIT_KEY);
+    } else {
+      try {
+        localStorage.setItem(
+          SELECTED_BENEFIT_KEY,
+          JSON.stringify(selectedBenefit)
+        );
+      } catch (error) {
+        console.warn(
+          "No se pudo guardar selectedBenefit en localStorage",
+          error
+        );
+      }
+    }
+  }, [selectedBenefit]);
 
   // Funciones principales
   const getBenefits = useCallback(async (): Promise<void> => {
@@ -171,6 +201,7 @@ export const BenefitAPIProvider: React.FC<BenefitProviderProps> = ({
     // Estados generales
     loading,
     benefits,
+    selectedBenefit,
     benefitPurchases,
     paginatedBenefits,
     paginatedBenefitsUseRequested,
@@ -187,6 +218,7 @@ export const BenefitAPIProvider: React.FC<BenefitProviderProps> = ({
     deleteBenefit,
 
     // Funciones auxiliares
+    setSelectedBenefit,
     refreshBenefitsAfterDeletion,
     refreshBenefitsAfterAcceptance,
   };

--- a/src/teacher/hooks/benefits/benefitList/useBenefitTeacherActions.ts
+++ b/src/teacher/hooks/benefits/benefitList/useBenefitTeacherActions.ts
@@ -1,14 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import type { BenefitActionHandlers } from "../../../utils/benefitList.utils";
+import type { BenefitResponseInterface } from "../../../../benefit/types/benefit.types";
 import { useBenefitAPI } from "../../useBenefitAPI";
 import { useConfirmation } from "../../../../shared/hooks/useConfirmation";
 import { useToaster } from "../../../../shared/hooks/useToaster";
-
-export type BenefitActionHandlers = {
-  onDelete: (benefitId: number, name: string) => void;
-  onViewPurchases: (benefitId: number) => void;
-  onAcceptUse: (benefitId: number, name: string) => void;
-};
 
 export const useBenefitTeacherActions = (): {
   actions: BenefitActionHandlers;
@@ -18,6 +14,7 @@ export const useBenefitTeacherActions = (): {
   const {
     deleteBenefit,
     acceptUseBenefit,
+    setSelectedBenefit,
     refreshBenefitsAfterDeletion,
     refreshBenefitsAfterAcceptance,
     loading: apiLoading,
@@ -52,10 +49,11 @@ export const useBenefitTeacherActions = (): {
   );
 
   const handleViewPurchases = useCallback(
-    (benefitId: number) => {
+    (benefit: BenefitResponseInterface, benefitId: number) => {
+      setSelectedBenefit(benefit);
       navigate(`/dashboard/teacher/beneficio/list/${benefitId}`);
     },
-    [navigate]
+    [navigate, setSelectedBenefit]
   );
 
   const handleAcceptUseBenefit = useCallback(

--- a/src/teacher/hooks/benefits/benefitPurchase/useBenefitPurchaseActions.ts
+++ b/src/teacher/hooks/benefits/benefitPurchase/useBenefitPurchaseActions.ts
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useBenefitAPI } from "../../useBenefitAPI";
 import { useToaster } from "../../../../shared/hooks/useToaster";
 
@@ -6,11 +7,12 @@ import { useToaster } from "../../../../shared/hooks/useToaster";
  * Hook para manejar las acciones sobre los canjes de beneficios
  */
 export const useBenefitPurchasesActions = () => {
+  const navigate = useNavigate();
   const { acceptUseBenefit } = useBenefitAPI();
   const { showToast } = useToaster();
   const [loading, setLoading] = useState(false);
 
-  const handleAcceptUse = async (id: number) => {
+  const acceptUse = async (id: number) => {
     setLoading(true);
     try {
       await acceptUseBenefit(id);
@@ -19,19 +21,33 @@ export const useBenefitPurchasesActions = () => {
         type: "success",
         position: "bottom-right",
       });
+      return true;
     } catch (error) {
       showToast({
         title: "Error al aceptar el uso del beneficio",
         type: "error",
         position: "bottom-right",
       });
+      return false;
     } finally {
       setLoading(false);
     }
   };
 
+  const backToBenefits = () => {
+    navigate("/dashboard/teacher/beneficio/list");
+  };
+
+  const actions = useMemo(
+    () => ({
+      onAcceptUse: acceptUse,
+      onNavigateBack: backToBenefits,
+    }),
+    [acceptUse, backToBenefits]
+  );
+
   return {
-    acceptUse: handleAcceptUse,
+    actions,
     loading,
   };
 };

--- a/src/teacher/hooks/benefits/benefitPurchase/useBenefitPurchaseData.ts
+++ b/src/teacher/hooks/benefits/benefitPurchase/useBenefitPurchaseData.ts
@@ -7,8 +7,12 @@ import usePaginationParams from "../../../../shared/hooks/usePaginateParams";
  * Hook central para cargar y manejar los datos de canjes de un beneficio
  */
 export const useBenefitPurchaseData = (benefitId: number) => {
-  const { loading, paginatedBenefitsPurchases, getPaginatedBenefitsPurchases } =
-    useBenefitAPI();
+  const {
+    loading,
+    paginatedBenefitsPurchases,
+    getPaginatedBenefitsPurchases,
+    selectedBenefit,
+  } = useBenefitAPI();
 
   const {
     paginationParams,
@@ -55,14 +59,14 @@ export const useBenefitPurchaseData = (benefitId: number) => {
   ]);
 
   /**
-   * Carga inicial de canjes
+   * Carga inicial
    */
   useEffect(() => {
     loadPurchases();
   }, [loadPurchases, benefitId]);
 
   /**
-   * Reinicia la paginación al cambiar el filtro (solo si hay paginación)
+   * Reinicia paginación al cambiar filtro
    */
   useEffect(() => {
     if (hasPagination) {
@@ -74,7 +78,6 @@ export const useBenefitPurchaseData = (benefitId: number) => {
     if (Array.isArray(paginatedBenefitsPurchases)) {
       return paginatedBenefitsPurchases;
     }
-
     return paginatedBenefitsPurchases?.results ?? [];
   }, [paginatedBenefitsPurchases]);
 
@@ -82,7 +85,6 @@ export const useBenefitPurchaseData = (benefitId: number) => {
     if (Array.isArray(paginatedBenefitsPurchases)) {
       return null;
     }
-
     return paginatedBenefitsPurchases
       ? {
           currentPage: paginatedBenefitsPurchases.currentPage,
@@ -100,13 +102,12 @@ export const useBenefitPurchaseData = (benefitId: number) => {
     loading,
     activeFilter,
     setActiveFilter,
-
-    // Datos Generales
+    selectedBenefit,
     filteredPurchases,
     paginationInfo,
     hasPagination,
 
-    // Funciones
+    // Acciones
     refetch: loadPurchases,
   };
 };

--- a/src/teacher/hooks/benefits/benefitPurchase/useBenefitPurchaseView.ts
+++ b/src/teacher/hooks/benefits/benefitPurchase/useBenefitPurchaseView.ts
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useBenefitPurchaseData } from "./useBenefitPurchaseData";
+import { useBenefitPurchasesActions } from "./useBenefitPurchaseActions";
+import { useBenefitAPI } from "../../useBenefitAPI";
+
+export const useBenefitPurchaseView = () => {
+  const { id } = useParams<{ id: string }>();
+  const benefitId = Number.parseInt(id || "0", 10);
+
+  const {
+    loading: dataLoading,
+    activeFilter,
+    setActiveFilter,
+    selectedBenefit,
+    filteredPurchases,
+    paginationInfo,
+    hasPagination,
+    refetch,
+  } = useBenefitPurchaseData(benefitId);
+
+  const { actions, loading: actionLoading } = useBenefitPurchasesActions();
+
+  const { setSelectedBenefit } = useBenefitAPI();
+
+  useEffect(() => {
+    if (selectedBenefit) {
+      const currentId =
+        "benefitId" in selectedBenefit
+          ? selectedBenefit.benefitId
+          : selectedBenefit.id;
+      if (currentId !== benefitId) {
+        setSelectedBenefit(null);
+      }
+    }
+  }, [benefitId, selectedBenefit, setSelectedBenefit]);
+
+  const handleBack = () => {
+    setSelectedBenefit(null);
+    actions.onNavigateBack();
+  };
+
+  const handleAcceptUse = async (purchaseId: number) => {
+    const success = await actions.onAcceptUse(purchaseId);
+    if (success) {
+      await refetch();
+    }
+  };
+
+  const loading = dataLoading || actionLoading;
+
+  return {
+    selectedBenefit,
+    loading,
+    activeFilter,
+    setActiveFilter,
+    filteredPurchases,
+    paginationInfo,
+    hasPagination,
+    handleBack,
+    handleAcceptUse,
+  };
+};

--- a/src/teacher/services/urls.ts
+++ b/src/teacher/services/urls.ts
@@ -8,7 +8,7 @@ export const urls = {
   PaginatedBenefitTeacher: "/benefits/teacher/paginated",
   PaginatedBenefitUseRequested: "/benefits/teacher/use-requested/paginated",
   PaginatedBenefitPurchases: (benefitId: number) =>
-    `/benefits/teacher/purchases/${benefitId}`,
+    `/benefits/teacher/purchases/paginated/${benefitId}`,
   AcceptUseBenefit: (id: number) => `/benefits/teacher/accept-use/${id}`,
 
   // Stats

--- a/src/teacher/utils/benefitList.utils.ts
+++ b/src/teacher/utils/benefitList.utils.ts
@@ -2,11 +2,17 @@ import {
   isBenefitUseRequested,
   getBenefitDisplayName,
 } from "../../benefit/utils/benefit.utils";
-import type { TeacherBenefitType } from "../../benefit/types/benefit.types";
+import type {
+  BenefitResponseInterface,
+  TeacherBenefitType,
+} from "../../benefit/types/benefit.types";
 
 export type BenefitActionHandlers = {
   onDelete: (benefitId: number, name: string) => void;
-  onViewPurchases: (benefitId: number) => void;
+  onViewPurchases: (
+    benefit: BenefitResponseInterface,
+    benefitId: number
+  ) => void;
   onAcceptUse: (benefitId: number, name: string) => void;
 };
 

--- a/src/teacher/views/benefitsView/benefitPurchaseView/BenefitPurchasesView.module.css
+++ b/src/teacher/views/benefitsView/benefitPurchaseView/BenefitPurchasesView.module.css
@@ -8,6 +8,10 @@
   margin-bottom: 2rem;
 }
 
+.filters {
+  margin-top: 2rem;
+}
+
 .content {
   margin-top: 2rem;
   width: 100%;

--- a/src/teacher/views/benefitsView/benefitPurchaseView/BenefitPurchasesView.tsx
+++ b/src/teacher/views/benefitsView/benefitPurchaseView/BenefitPurchasesView.tsx
@@ -1,66 +1,40 @@
-import { useParams, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { FaArrowLeft } from "react-icons/fa";
 import Button from "../../../../shared/components/Button/ButtonComponent";
+import LoadingSpinnerComponent from "../../../../shared/components/LoadingSpinner/LoadingSpinnerComponent";
 import BenefitPurchaseInfo from "../../../components/benefitsView/benefitPurchases/benefitPurchaseInfo/BenefitPurchaseInfo";
 import BenefitPurchaseFilters from "../../../components/benefitsView/benefitPurchases/benefitPurchasesFilters/BenefitPurchaseFilters";
 import BenefitPurchaseList from "../../../components/benefitsView/benefitPurchases/benefitPurchaseList/BenefitPurchaseList";
-import { useBenefitPurchaseData } from "../../../hooks/benefits/benefitPurchase/useBenefitPurchaseData";
-import { useBenefitPurchasesActions } from "../../../hooks/benefits/benefitPurchase/useBenefitPurchaseActions";
+import {
+  benefitPurchasesContainerVariants,
+  benefitItemVariants,
+} from "../../../constants/animations/benefitTeacher.animations";
+import { useBenefitPurchaseView } from "../../../hooks/benefits/benefitPurchase/useBenefitPurchaseView";
 import styles from "./BenefitPurchasesView.module.css";
 
 const BenefitPurchasesView: React.FC = () => {
-  const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
-  const benefitId = Number.parseInt(id || "0", 10);
-
   const {
+    selectedBenefit,
     loading,
     activeFilter,
     setActiveFilter,
     filteredPurchases,
     paginationInfo,
     hasPagination,
-    refetch,
-  } = useBenefitPurchaseData(benefitId);
-
-  const { acceptUse, loading: acceptingUse } = useBenefitPurchasesActions();
-
-  const handleBack = () => {
-    navigate("/dashboard/teacher/beneficio/list");
-  };
-
-  const handleAcceptUse = async (purchaseId: number) => {
-    await acceptUse(purchaseId);
-    await refetch();
-  };
-
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: { staggerChildren: 0.1 },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { y: 20, opacity: 0 },
-    visible: { y: 0, opacity: 1 },
-  };
-
-  const firstPurchase =
-    filteredPurchases.length > 0 ? filteredPurchases[0] : null;
+    handleBack,
+    handleAcceptUse,
+  } = useBenefitPurchaseView();
 
   return (
     <motion.div
-      variants={containerVariants}
+      variants={benefitPurchasesContainerVariants}
       initial="hidden"
       animate="visible"
       className={styles.purchasesView}
     >
       {/* Botón Volver */}
       <motion.div
-        variants={itemVariants}
+        variants={benefitItemVariants}
         className={styles.backButtonContainer}
       >
         <Button
@@ -73,16 +47,14 @@ const BenefitPurchasesView: React.FC = () => {
         </Button>
       </motion.div>
 
-      {/* Info del Beneficio */}
-      {firstPurchase && (
-        <motion.div variants={itemVariants}>
-          <BenefitPurchaseInfo purchase={firstPurchase} />
-        </motion.div>
-      )}
+      {/* Información del Beneficio */}
+      <motion.div variants={benefitItemVariants}>
+        <BenefitPurchaseInfo benefit={selectedBenefit} />
+      </motion.div>
 
-      {/* Filtros - SOLO SI HAY PAGINACIÓN */}
+      {/* Filtros - Solo si hay paginación */}
       {hasPagination && (
-        <motion.div variants={itemVariants}>
+        <motion.div variants={benefitItemVariants} className={styles.filters}>
           <BenefitPurchaseFilters
             activeFilter={activeFilter}
             onFilterChange={setActiveFilter}
@@ -90,25 +62,16 @@ const BenefitPurchasesView: React.FC = () => {
         </motion.div>
       )}
 
-      {/* Content */}
-      <motion.div variants={itemVariants} className={styles.content}>
+      {/* Lista de Canjes */}
+      <motion.div variants={benefitItemVariants} className={styles.content}>
         {loading ? (
-          <div className={styles.loadingContainer}>
-            <div className={styles.spinner} />
-            <p className={styles.loadingText}>Cargando canjes...</p>
-          </div>
-        ) : filteredPurchases.length === 0 ? (
-          <div className={styles.emptyState}>
-            <p className={styles.emptyText}>
-              No hay canjes para mostrar con el filtro seleccionado
-            </p>
-          </div>
+          <LoadingSpinnerComponent color="#f76300" />
         ) : (
           <BenefitPurchaseList
             purchases={filteredPurchases}
             paginationInfo={paginationInfo}
             onAcceptUse={handleAcceptUse}
-            loading={acceptingUse}
+            loading={loading}
           />
         )}
       </motion.div>


### PR DESCRIPTION
# Descripción
Corregir la paginación en los canjes de beneficio

# Explicación
Se corrigió la paginación de canjes de beneficio. Ahora el docente puede filtrar entre los distintos estados de benefitPurchase (comprado, uso solicitado, usado)
<img width="1346" height="750" alt="image" src="https://github.com/user-attachments/assets/6e16858c-b6e1-4ff5-bf6e-72c882cd3bdb" />
<img width="1349" height="743" alt="image" src="https://github.com/user-attachments/assets/5da6ad80-3ca5-4b1a-a162-1ee3eaf622da" />

Además, se agregó persistencia al beneficio seleccionado por el docente para ver sus canjes (por ahora en localStorage, futuro crear un getBenefitById y guardar solo el id en el localStorage)

# Consideraciones
Sobre el beneficio que se guarda en el localStorage: No agregué ningun useEffect que se fije si se va de los canjes navegando por la app, solo lo quito si le da al boton de volver a beneficios. Es una solución temporal esto, y dejarla a medias así hace que le tenga que poner atención en otro momento (asi laburo si o si después)

# Issue relacionada
Closes #255 