### PR TITLE
[#273] feat: Visualización de resultados de actividades

### DIFF
--- a/src/apps/StudentApp.tsx
+++ b/src/apps/StudentApp.tsx
@@ -23,7 +23,7 @@ import { PreguntadosProvider } from "../activity/contexts/preguntadosContext/Pre
 import { PreguntadosGameProvider } from "../shared/contexts/gamesContext/preguntadosGameContext/PreguntadosGameProvider";
 import { WalletStudentProvider } from "../student/context/walletStudentContext/WalletStudentProvider";
 import { BenefitStudentProvider } from "../student/context/benefitStudentContext/BenefitStudentProvider";
-import { StoreProvider } from "../student/context/storeStudentContext/StoreStudentProvider";
+import { StoreProvider } from "@/student/context/storeStudentContext/StoreStudentProvider";
 import { ActionsProvider } from "../investments/contexts/actionsContext/ActionsStudentProvider";
 import { PlazoFijoProvider } from "../investments/contexts/plazoFijoContext/PlazoFijoStudentProvider";
 import { CajaDeAhorroProvider } from "../investments/contexts/cajaDeAhorroContext/CajaDeAhorroStudentProvider";
@@ -32,6 +32,7 @@ import { NotificationProvider } from "../notifications/contexts/NotificationsPro
 //VIEWS
 import StudentActivitiesView from "../student/views/studentActivitiesView/StudentActivitiesView";
 import StudentActivityView from "../student/views/studentActivityView/StudentActivityView";
+import StudentActivityResultsView from "../student/views/studentActivityResultsView/StudentActivityResultsView";
 import StudentCompletedActivityView from "../student/views/studentCompletedActivityView/StudentCompletedActivityView";
 import StudentPlayActivityView from "../student/views/studentPlayActivityView/StudentPlayActivityView";
 import StudentBenefitsView from "../student/views/studentBenefitsView/StudentBenefitsView";
@@ -156,6 +157,11 @@ const StudentApp = () => {
             <Route
               path="actividades/:id/review"
               element={<StudentCompletedActivityView />}
+            />
+            {/* RESULTS */}
+            <Route
+              path="actividades/:id/results"
+              element={<StudentActivityResultsView />}
             />
             {/* BENEFICIOS */}
             <Route path="beneficios/list" element={<StudentBenefitsView />} />

--- a/src/shared/constants/difficulty.constants.ts
+++ b/src/shared/constants/difficulty.constants.ts
@@ -1,0 +1,31 @@
+export const DIFFICULTY_COLORS: Record<
+  string,
+  { bg: string; text: string; label: string }
+> = {
+  FACIL: {
+    bg: "#dcfce7",
+    text: "#10b981",
+    label: "Fácil",
+  },
+  MEDIO: {
+    bg: "#fef3c7",
+    text: "#f59e0b",
+    label: "Medio",
+  },
+  DIFICIL: {
+    bg: "#fee2e2",
+    text: "#ef4444",
+    label: "Difícil",
+  },
+};
+
+export const getDifficultyColor = (difficulty: string) => {
+  const upperKey = difficulty.toUpperCase();
+  return (
+    DIFFICULTY_COLORS[upperKey] || {
+      bg: "#e5e7eb",
+      text: "#6b7280",
+      label: difficulty,
+    }
+  );
+};

--- a/src/shared/contexts/gamesContext/ahorcadoGameContext/AhorcadoGameProvider.tsx
+++ b/src/shared/contexts/gamesContext/ahorcadoGameContext/AhorcadoGameProvider.tsx
@@ -69,6 +69,18 @@ export const AhorcadoGameProvider: React.FC<AhorcadoGameProviderProps> = ({
   const maxErrors = getMaxErrors();
   const livesRemaining = maxErrors - wrongGuesses;
 
+  // Letras correctas: las que están en la palabra
+  const correctAnswers = guessedLetters.filter((letter) =>
+    gameConfig?.word.toLowerCase().includes(letter)
+  ).length;
+
+  // Letras incorrectas: las que no están en la palabra
+  const incorrectAnswers = wrongGuesses;
+
+  const score = isGameWon ? 100 : 0;
+
+  const unanswered = 0;
+
   // Funciones del juego
   const resetGame = () => {
     setGuessedLetters([]);
@@ -121,6 +133,10 @@ export const AhorcadoGameProvider: React.FC<AhorcadoGameProviderProps> = ({
     isGameLost,
     maxErrors,
     livesRemaining,
+    score,
+    correctAnswers,
+    incorrectAnswers,
+    unanswered,
 
     // Funciones del juego
     handleGuessLetter,

--- a/src/shared/contexts/gamesContext/completarOracionGameContext/CompletarOracionGameProvider.tsx
+++ b/src/shared/contexts/gamesContext/completarOracionGameContext/CompletarOracionGameProvider.tsx
@@ -103,6 +103,12 @@ export const CompletarOracionGameProvider: React.FC<
   const isGameWon = totalMissingWords > 0 && getScore() >= 60;
   const isGameLost = false; // Este juego no tiene condición de pérdida
 
+  const score = getScore();
+  // Oraciones incorrectas: palabras completadas que son incorrectas
+  const incorrectAnswers = completedWords - correctAnswers;
+  // Oraciones sin completar: palabras faltantes que no han sido respondidas
+  const unanswered = totalMissingWords - completedWords;
+
   // Funciones del juego
   const handleInputChange = (
     sentenceIndex: number,
@@ -159,9 +165,12 @@ export const CompletarOracionGameProvider: React.FC<
     // Estados calculados
     totalMissingWords,
     completedWords,
-    correctAnswers,
     isGameWon,
     isGameLost,
+    score,
+    correctAnswers,
+    incorrectAnswers,
+    unanswered,
 
     // Funciones del juego
     resetGame,

--- a/src/shared/contexts/gamesContext/desafioClasificacionGameContext/DesafioClasificacionGameProvider.tsx
+++ b/src/shared/contexts/gamesContext/desafioClasificacionGameContext/DesafioClasificacionGameProvider.tsx
@@ -252,10 +252,13 @@ export const DesafioClasificacionGameProvider: React.FC<
     setDraggedConcept(null);
   };
 
+  const correctAnswers = verificationResults?.totalCorrect || 0;
+  const incorrectAnswers = verificationResults?.incorrect.length || 0;
+  const unanswered = availableConcepts.length;
+
   const value: DesafioClasificacionGameContextType = {
     // Estados del juego
     gameConfig,
-    score,
     gameStatus,
     draggedConcept,
     conceptsInCategories,
@@ -269,6 +272,10 @@ export const DesafioClasificacionGameProvider: React.FC<
     totalConcepts,
     isGameLost,
     isGameWon,
+    score,
+    correctAnswers,
+    incorrectAnswers,
+    unanswered,
 
     // Funciones del juego
     startGame,

--- a/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameContext.type.ts
+++ b/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameContext.type.ts
@@ -9,6 +9,10 @@ export interface NoLudicaGameContextType {
   gameStarted?: boolean;
   isGameLost: boolean;
   isGameWon: boolean;
+  score: number;
+  correctAnswers: number;
+  incorrectAnswers: number;
+  unanswered: number;
 
   // Estados calculados
   studentResponse: string;

--- a/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameProvider.tsx
+++ b/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameProvider.tsx
@@ -94,6 +94,10 @@ export const NoLudicaGameProvider: React.FC<NoLudicaGameProviderProps> = ({
     studentResponse,
     isGameLost,
     isGameWon,
+    score: 0,
+    correctAnswers: 0,
+    incorrectAnswers: 0,
+    unanswered: 0,
   };
   return (
     <NoLudicaGameContext.Provider value={value}>

--- a/src/shared/contexts/gamesContext/preguntadosGameContext/PreguntadosGameProvider.tsx
+++ b/src/shared/contexts/gamesContext/preguntadosGameContext/PreguntadosGameProvider.tsx
@@ -55,6 +55,19 @@ export const PreguntadosGameProvider: React.FC<
   const [questionStartTime, setQuestionStartTime] = useState<number>(0);
   const [showExplosion, setShowExplosion] = useState(false);
 
+  const getFinalScore = useCallback(() => {
+    const percentage = Math.round(
+      (results.filter((result) => result.isCorrect).length / questions.length) *
+        100
+    );
+    const isPassed = percentage >= 60;
+
+    return {
+      percentage,
+      isPassed,
+    };
+  }, [results, questions]);
+
   useEffect(() => {
     if (mode === "preview" && config && configQuestions.length > 0) {
       setGameConfig({
@@ -98,7 +111,7 @@ export const PreguntadosGameProvider: React.FC<
       });
       setQuestions(configQuestions);
     }
-  }, [mode, config?.totalQuestions, configQuestions?.length]);
+  }, [mode, config, configQuestions]);
 
   // Estados calculados
   const currentQuestion = questions[currentQuestionIndex] || null;
@@ -113,6 +126,14 @@ export const PreguntadosGameProvider: React.FC<
     correctAnswers >= Math.ceil(totalQuestions * 0.6);
   const isGameLost = gamePhase === "finished" && !isGameWon;
   const gameStarted = gamePhase !== "waiting";
+
+  const incorrectAnswers = results.filter(
+    (result) => !result.isCorrect && result.selectedAnswer !== null
+  ).length;
+  const unanswered = results.filter(
+    (result) => result.selectedAnswer === null
+  ).length;
+  const score = getFinalScore().percentage;
 
   // Funciones auxiliares
   const getMaxTimePerQuestion = useCallback(() => {
@@ -142,16 +163,6 @@ export const PreguntadosGameProvider: React.FC<
       strokeDashoffset,
     };
   }, [getMaxTimePerQuestion, timeRemaining]);
-
-  const getFinalScore = useCallback(() => {
-    const percentage = Math.round((correctAnswers / totalQuestions) * 100);
-    const isPassed = percentage >= 60;
-
-    return {
-      percentage,
-      isPassed,
-    };
-  }, [correctAnswers, totalQuestions]);
 
   const getCorrectAnswerIndex = useCallback(() => {
     return currentQuestion?.options.findIndex((opt) => opt.isCorrect) ?? -1;
@@ -238,6 +249,7 @@ export const PreguntadosGameProvider: React.FC<
 
     setResults((prev) => [...prev, result]);
     setGamePhase("answered");
+    setTimeRemaining(timeSpent);
   }, [
     gamePhase,
     currentQuestion,
@@ -345,6 +357,9 @@ export const PreguntadosGameProvider: React.FC<
     isGameWon,
     isGameLost,
     gameStarted,
+    score,
+    incorrectAnswers,
+    unanswered,
 
     // Funciones del juego
     selectAnswer,

--- a/src/shared/registry/games/gameResultsFactory.ts
+++ b/src/shared/registry/games/gameResultsFactory.ts
@@ -1,0 +1,27 @@
+import type { GameType } from "@/shared/types";
+import type { ActivityResultsStrategy } from "@/shared/strategies/interfaces/ActivityResultsStategy.interface";
+import { AhorcadoResultsStrategy } from "@/shared/strategies/renderers/activityResults/AhorcadoResultsStrategy";
+import { CompletarOracionResultsStrategy } from "@/shared/strategies/renderers/activityResults/CompletarOracionResultsStrategy";
+import { DesafioClasificacionResultsStrategy } from "@/shared/strategies/renderers/activityResults/DesafioClasificacionResultsStrategy";
+import { NoLudicaResultsStrategy } from "@/shared/strategies/renderers/activityResults/NoLudicaResultsStrategy";
+import { PreguntadosResultsStrategy } from "@/shared/strategies/renderers/activityResults/PreguntadosResultsStrategy";
+import { DefaultResultsStrategy } from "@/shared/strategies/renderers/activityResults/DefaultResultsStrategy";
+
+export class ActivityResultsStrategyFactory {
+  static createStrategy(gameType: GameType): ActivityResultsStrategy {
+    switch (gameType) {
+      case "ahorcado":
+        return new AhorcadoResultsStrategy();
+      case "desafio de clasificacion":
+        return new DesafioClasificacionResultsStrategy();
+      case "completar oracion":
+        return new CompletarOracionResultsStrategy();
+      case "preguntados":
+        return new PreguntadosResultsStrategy();
+      case "no ludica":
+        return new NoLudicaResultsStrategy();
+      default:
+        return new DefaultResultsStrategy();
+    }
+  }
+}

--- a/src/shared/registry/index.ts
+++ b/src/shared/registry/index.ts
@@ -5,3 +5,5 @@ export { getGameTypeFromActivityName } from "./detailsGame/detailsMapping";
 export { createGameConfig } from "./games/gameConfigFactory";
 export { GameConfigRendererRegistry } from "./games/gameConfigRendererRegistry";
 export { gameHooksRegistry } from "./games/gameHooksRegistry";
+
+export { ActivityResultsStrategyFactory } from "./games/gameResultsFactory";

--- a/src/shared/strategies/interfaces/ActivityResultsStategy.interface.ts
+++ b/src/shared/strategies/interfaces/ActivityResultsStategy.interface.ts
@@ -1,0 +1,10 @@
+export interface StatsLabels {
+  correctAnswers: string | null;
+  incorrectAnswers: string | null;
+  unanswered: string | null;
+}
+
+export interface ActivityResultsStrategy {
+  getStatsLabels(): StatsLabels;
+  shouldShowScore(): boolean;
+}

--- a/src/shared/strategies/renderers/activityResults/AhorcadoResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/AhorcadoResultsStrategy.ts
@@ -1,0 +1,18 @@
+import type {
+  ActivityResultsStrategy,
+  StatsLabels,
+} from "../../interfaces/ActivityResultsStategy.interface";
+
+export class AhorcadoResultsStrategy implements ActivityResultsStrategy {
+  getStatsLabels(): StatsLabels {
+    return {
+      correctAnswers: "Letras correctas",
+      incorrectAnswers: "Letras incorrectas",
+      unanswered: null, // No mostrar
+    };
+  }
+
+  shouldShowScore(): boolean {
+    return true;
+  }
+}

--- a/src/shared/strategies/renderers/activityResults/CompletarOracionResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/CompletarOracionResultsStrategy.ts
@@ -1,0 +1,20 @@
+import type {
+  ActivityResultsStrategy,
+  StatsLabels,
+} from "../../interfaces/ActivityResultsStategy.interface";
+
+export class CompletarOracionResultsStrategy
+  implements ActivityResultsStrategy
+{
+  getStatsLabels(): StatsLabels {
+    return {
+      correctAnswers: "Oraciones correctas",
+      incorrectAnswers: "Oraciones incorrectas",
+      unanswered: "Oraciones sin completar",
+    };
+  }
+
+  shouldShowScore(): boolean {
+    return true;
+  }
+}

--- a/src/shared/strategies/renderers/activityResults/DefaultResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/DefaultResultsStrategy.ts
@@ -1,0 +1,18 @@
+import type {
+  ActivityResultsStrategy,
+  StatsLabels,
+} from "../../interfaces/ActivityResultsStategy.interface";
+
+export class DefaultResultsStrategy implements ActivityResultsStrategy {
+  getStatsLabels(): StatsLabels {
+    return {
+      correctAnswers: "Respuestas correctas",
+      incorrectAnswers: "Respuestas incorrectas",
+      unanswered: "Sin responder",
+    };
+  }
+
+  shouldShowScore(): boolean {
+    return true;
+  }
+}

--- a/src/shared/strategies/renderers/activityResults/DesafioClasificacionResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/DesafioClasificacionResultsStrategy.ts
@@ -1,0 +1,20 @@
+import type {
+  ActivityResultsStrategy,
+  StatsLabels,
+} from "../../interfaces/ActivityResultsStategy.interface";
+
+export class DesafioClasificacionResultsStrategy
+  implements ActivityResultsStrategy
+{
+  getStatsLabels(): StatsLabels {
+    return {
+      correctAnswers: "Conceptos correctos",
+      incorrectAnswers: "Conceptos incorrectos",
+      unanswered: "Conceptos no clasificados",
+    };
+  }
+
+  shouldShowScore(): boolean {
+    return true;
+  }
+}

--- a/src/shared/strategies/renderers/activityResults/NoLudicaResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/NoLudicaResultsStrategy.ts
@@ -1,0 +1,18 @@
+import type {
+  ActivityResultsStrategy,
+  StatsLabels,
+} from "../../interfaces/ActivityResultsStategy.interface";
+
+export class NoLudicaResultsStrategy implements ActivityResultsStrategy {
+  getStatsLabels(): StatsLabels {
+    return {
+      correctAnswers: null, // No mostrar nada
+      incorrectAnswers: null,
+      unanswered: null,
+    };
+  }
+
+  shouldShowScore(): boolean {
+    return false;
+  }
+}

--- a/src/shared/strategies/renderers/activityResults/PreguntadosResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/PreguntadosResultsStrategy.ts
@@ -1,0 +1,18 @@
+import type {
+  ActivityResultsStrategy,
+  StatsLabels,
+} from "../../interfaces/ActivityResultsStategy.interface";
+
+export class PreguntadosResultsStrategy implements ActivityResultsStrategy {
+  getStatsLabels(): StatsLabels {
+    return {
+      correctAnswers: "Respuestas correctas",
+      incorrectAnswers: "Respuestas incorrectas",
+      unanswered: "Respuestas sin responder",
+    };
+  }
+
+  shouldShowScore(): boolean {
+    return true;
+  }
+}

--- a/src/shared/types/Games.type.ts
+++ b/src/shared/types/Games.type.ts
@@ -14,6 +14,10 @@ export interface GameHook {
   isGameWon: boolean;
   isGameLost: boolean;
   gameStarted?: boolean;
+  score: number;
+  correctAnswers: number;
+  incorrectAnswers: number;
+  unanswered: number;
   resetGame: () => void;
   startGame: () => void;
   initializeGame?: () => void;

--- a/src/student/adapters/activityAdapter.ts
+++ b/src/student/adapters/activityAdapter.ts
@@ -35,6 +35,7 @@ export function mapActivityToUI(
       : undefined,
     reward: isNotApproved ? undefined : `${activity.reward} monedas`,
 
+    attempts: activity.attempts,
     attemptsLabel: `${activity.remainingAttempts} / ${activity.attempts} intentos`,
     remainingAttempts: activity.remainingAttempts,
     noAttempts: activity.remainingAttempts === 0,
@@ -47,6 +48,7 @@ export function mapActivityToUI(
           "es-ES"
         )}`
       : undefined,
+    completedAt: !isNotApproved ? activity.completedAt : undefined,
   };
 }
 

--- a/src/student/components/studentActivitiesViewComponents/activityCard/ActivityCard.module.css
+++ b/src/student/components/studentActivitiesViewComponents/activityCard/ActivityCard.module.css
@@ -171,6 +171,27 @@
   color: var(--color-text-light);
 }
 
+.buttonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.secondaryButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  border-radius: 6px;
+  transition: all 0.3s ease;
+  color: var(--color-text-light);
+  white-space: nowrap;
+}
+
 .actionButton {
   display: flex;
   align-items: center;
@@ -203,6 +224,7 @@
   pointer-events: none;
 }
 
+/* Responsive Design */
 @media (max-width: 768px) {
   .cardHeader {
     padding: 1rem 1rem 0.75rem 1rem;
@@ -260,6 +282,11 @@
     gap: 0.75rem;
   }
 
+  .buttonGroup {
+    width: 100%;
+  }
+
+  .secondaryButton,
   .actionButton {
     width: 100%;
     padding: 0.75rem;

--- a/src/student/components/studentActivitiesViewComponents/activityCard/ActivityCard.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityCard/ActivityCard.tsx
@@ -11,9 +11,14 @@ import styles from "./ActivityCard.module.css";
 interface ActivityCardProps {
   activity: ActivityUI;
   onStart?: (activityId: string) => void;
+  onViewResults?: (activityId: string) => void;
 }
 
-const ActivityCard: React.FC<ActivityCardProps> = ({ activity, onStart }) => {
+const ActivityCard: React.FC<ActivityCardProps> = ({
+  activity,
+  onStart,
+  onViewResults,
+}) => {
   const statusConfig = getActivityStatusConfig(activity.status);
   const RandomIcon = getRandomActivityIcon();
 
@@ -27,7 +32,13 @@ const ActivityCard: React.FC<ActivityCardProps> = ({ activity, onStart }) => {
       : statusConfig.buttonText;
 
   const handleActionButton = async () => {
-    if (activity.status === "PUBLISHED" && !activity.noAttempts && onStart) {
+    if (activity.status === "APPROVED" && onViewResults) {
+      onViewResults(activity.id);
+    } else if (
+      activity.status === "PUBLISHED" &&
+      !activity.noAttempts &&
+      onStart
+    ) {
       onStart(activity.id);
     }
   };
@@ -49,7 +60,7 @@ const ActivityCard: React.FC<ActivityCardProps> = ({ activity, onStart }) => {
               }}
               transition={{
                 duration: 2,
-                repeat: Infinity,
+                repeat: Number.POSITIVE_INFINITY,
                 repeatType: "reverse",
               }}
             >

--- a/src/student/components/studentActivitiesViewComponents/activityCard/ActivityCard.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityCard/ActivityCard.tsx
@@ -10,8 +10,16 @@ import styles from "./ActivityCard.module.css";
 
 interface ActivityCardProps {
   activity: ActivityUI;
-  onStart?: (activityId: string) => void;
-  onViewResults?: (activityId: string) => void;
+  onStart?: (
+    activityId: string,
+    remainingAttempts: number,
+    completedAt?: string
+  ) => void;
+  onViewResults?: (
+    activityId: string,
+    remainingAttempts: number,
+    completedAt?: string
+  ) => void;
 }
 
 const ActivityCard: React.FC<ActivityCardProps> = ({
@@ -33,15 +41,31 @@ const ActivityCard: React.FC<ActivityCardProps> = ({
 
   const handleActionButton = async () => {
     if (activity.status === "APPROVED" && onViewResults) {
-      onViewResults(activity.id);
+      onViewResults(
+        activity.id,
+        activity.remainingAttempts,
+        activity.completedAt
+      );
     } else if (
       activity.status === "PUBLISHED" &&
       !activity.noAttempts &&
       onStart
     ) {
-      onStart(activity.id);
+      onStart(activity.id, activity.remainingAttempts, activity.completedAt);
     }
   };
+
+  const handleViewLastAttempt = () => {
+    if (onViewResults) {
+      onViewResults(
+        activity.id,
+        activity.remainingAttempts,
+        activity.completedAt
+      );
+    }
+  };
+
+  const hasAttemptedActivity = activity.remainingAttempts < activity.attempts;
 
   return (
     <motion.div
@@ -118,15 +142,27 @@ const ActivityCard: React.FC<ActivityCardProps> = ({
             </Badge>
           </div>
 
-          <Button
-            variant={activity.status === "EXPIRED" ? "ghost" : "primary"}
-            className={styles.actionButton}
-            disabled={isDisabled}
-            onClick={handleActionButton}
-          >
-            <statusConfig.buttonIcon className={styles.buttonIcon} />
-            {buttonText}
-          </Button>
+          <div className={styles.buttonGroup}>
+            {hasAttemptedActivity && (
+              <Button
+                variant="secondary"
+                className={styles.secondaryButton}
+                onClick={handleViewLastAttempt}
+              >
+                Ver último intento
+              </Button>
+            )}
+
+            <Button
+              variant={activity.status === "EXPIRED" ? "ghost" : "primary"}
+              className={styles.actionButton}
+              disabled={isDisabled}
+              onClick={handleActionButton}
+            >
+              <statusConfig.buttonIcon className={styles.buttonIcon} />
+              {buttonText}
+            </Button>
+          </div>
         </div>
 
         <motion.div

--- a/src/student/components/studentActivitiesViewComponents/activityGrid/ActivityGrid.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityGrid/ActivityGrid.tsx
@@ -24,7 +24,7 @@ const ActivityGrid: React.FC<ActivityGridProps> = ({
   loading,
 }) => {
   const { isRow, toggleLayout } = useLayout();
-  const { viewActivity } = useActivityActions();
+  const { viewActivity, viewActivityResults } = useActivityActions();
 
   const itemVariants = {
     hidden: { y: 20, opacity: 0 },
@@ -33,6 +33,10 @@ const ActivityGrid: React.FC<ActivityGridProps> = ({
 
   const handleViewActivity = async (activityId: string) => {
     viewActivity(Number(activityId));
+  };
+
+  const handleViewResults = (activityId: string) => {
+    viewActivityResults(Number(activityId));
   };
 
   if (loading) {
@@ -76,6 +80,7 @@ const ActivityGrid: React.FC<ActivityGridProps> = ({
                 <ActivityCard
                   activity={activity}
                   onStart={handleViewActivity}
+                  onViewResults={handleViewResults}
                 />
               </motion.div>
             ))
@@ -85,7 +90,11 @@ const ActivityGrid: React.FC<ActivityGridProps> = ({
                 variants={itemVariants}
                 transition={{ delay: index * 0.1 }}
               >
-                <ActivityRow activity={activity} onStart={handleViewActivity} />
+                <ActivityRow
+                  activity={activity}
+                  onStart={handleViewActivity}
+                  onViewResults={handleViewResults}
+                />
               </motion.div>
             ))}
       </FlexBox>

--- a/src/student/components/studentActivitiesViewComponents/activityGrid/ActivityGrid.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityGrid/ActivityGrid.tsx
@@ -35,8 +35,16 @@ const ActivityGrid: React.FC<ActivityGridProps> = ({
     viewActivity(Number(activityId));
   };
 
-  const handleViewResults = (activityId: string) => {
-    viewActivityResults(Number(activityId));
+  const handleViewResults = (
+    activityId: string,
+    remainingAttempts: number,
+    completedAt?: string
+  ) => {
+    viewActivityResults(
+      Number(activityId),
+      remainingAttempts,
+      completedAt || undefined
+    );
   };
 
   if (loading) {

--- a/src/student/components/studentActivitiesViewComponents/activityRow/ActivityRow.module.css
+++ b/src/student/components/studentActivitiesViewComponents/activityRow/ActivityRow.module.css
@@ -18,14 +18,12 @@
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
 }
 
-/* Contenido principal */
 .mainContent {
   flex: 1;
   display: flex;
   flex-direction: row;
 }
 
-/* Información básica */
 .basicInfo {
   flex: 1;
   display: flex;
@@ -151,7 +149,6 @@
   color: var(--color-text-light);
 }
 
-/* Información secundaria */
 .secondaryInfo {
   flex: 1;
   display: flex;
@@ -197,7 +194,6 @@
   font-size: 12px;
 }
 
-/* Sección de puntuación */
 .scoreSection {
   position: absolute;
   top: -10px;
@@ -234,7 +230,6 @@
   line-height: 1;
 }
 
-/* Sección de acción */
 .actionSection {
   display: flex;
   min-height: 100px;
@@ -243,6 +238,26 @@
   gap: 10px;
   margin-left: 16px;
   flex-shrink: 0;
+}
+
+.buttonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.secondaryButton {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 100px;
+  text-align: center;
+  white-space: nowrap;
 }
 
 .actionButton {
@@ -262,7 +277,7 @@
   opacity: 0.6;
 }
 
-/* Responsive */
+/* Responsive Design */
 @media (max-width: 768px) {
   .activityRow {
     padding: 12px;
@@ -284,8 +299,15 @@
     align-self: stretch;
   }
 
+  .buttonGroup {
+    flex-direction: row;
+    gap: 8px;
+  }
+
+  .secondaryButton,
   .actionButton {
     width: 100%;
+    flex: 1;
   }
 
   .titleSection {

--- a/src/student/components/studentActivitiesViewComponents/activityRow/ActivityRow.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityRow/ActivityRow.tsx
@@ -1,5 +1,12 @@
 import { motion } from "framer-motion";
-import { FaCalendarAlt, FaRedo, FaStopwatch, FaCoins } from "react-icons/fa";
+import {
+  FaCalendarAlt,
+  FaRedo,
+  FaStopwatch,
+  FaCoins,
+  FaTimesCircle,
+  FaPlay,
+} from "react-icons/fa";
 import {
   Button,
   Badge,
@@ -9,14 +16,21 @@ import {
   getActivityIcon,
 } from "@/shared";
 import type { ActivityUI } from "../../../types/Activity.type";
-
 import { getActivityStatusConfig } from "../../../utils/activities.utils";
 import styles from "./ActivityRow.module.css";
 
 interface ActivityRowProps {
   activity: ActivityUI;
-  onStart?: (activityId: string) => void;
-  onViewResults?: (activityId: string) => void;
+  onStart?: (
+    activityId: string,
+    remainingAttempts: number,
+    completedAt?: string
+  ) => void;
+  onViewResults?: (
+    activityId: string,
+    remainingAttempts: number,
+    completedAt?: string
+  ) => void;
 }
 
 const ActivityRow: React.FC<ActivityRowProps> = ({
@@ -26,28 +40,62 @@ const ActivityRow: React.FC<ActivityRowProps> = ({
 }) => {
   const statusConfig = getActivityStatusConfig(activity.status);
   const isDisabled =
-    (activity.status === "CREATED" || activity.noAttempts) &&
-    !(activity.status === "APPROVED");
+    activity.status === "EXPIRED" && activity.remainingAttempts > 0;
+  const badgeText =
+    activity.noAttempts && !(activity.status === "APPROVED")
+      ? "Desaprobada"
+      : statusConfig.label;
+  const BadgeIcon =
+    activity.noAttempts && !(activity.status === "APPROVED")
+      ? FaTimesCircle
+      : statusConfig.icon;
+  const ButtonIcon =
+    activity.noAttempts && !(activity.status === "APPROVED")
+      ? FaPlay
+      : statusConfig.buttonIcon;
   const buttonText =
     activity.noAttempts && !(activity.status === "APPROVED")
-      ? "Sin intentos"
+      ? "Ver Resultados"
       : statusConfig.buttonText;
   const subjectColor = getSubjectColor(activity.subjectName);
 
   const handleActionButton = async () => {
-    if (activity.status === "APPROVED" && onViewResults) {
-      onViewResults(activity.id);
+    if (
+      (activity.completedAt ||
+        (activity.noAttempts && !(activity.status === "APPROVED"))) &&
+      onViewResults
+    ) {
+      onViewResults(
+        activity.id,
+        activity.remainingAttempts,
+        activity.completedAt
+      );
     } else if (
       activity.status === "PUBLISHED" &&
-      !activity.noAttempts &&
+      !activity.completedAt &&
       onStart
     ) {
-      onStart(activity.id);
+      onStart(activity.id, activity.remainingAttempts, activity.completedAt);
+    }
+  };
+
+  const handleViewLastAttempt = () => {
+    if (onViewResults) {
+      onViewResults(
+        activity.id,
+        activity.remainingAttempts,
+        activity.completedAt
+      );
     }
   };
 
   const ActivityIcon = getActivityIcon(activity.name);
   const activityColor = getActivityColor(activity.name);
+
+  const hasAttemptedActivity =
+    activity.remainingAttempts < activity.attempts &&
+    activity.remainingAttempts > 0 &&
+    activity.status === "PUBLISHED";
 
   return (
     <motion.div
@@ -117,20 +165,36 @@ const ActivityRow: React.FC<ActivityRowProps> = ({
       <div className={styles.actionSection}>
         <div className={styles.statusBadge}>
           <Badge>
-            <statusConfig.icon className={styles.statusIcon} />
-            {statusConfig.label}
+            <BadgeIcon className={styles.statusIcon} />
+            {badgeText}
           </Badge>
         </div>
 
-        <Button
-          variant={activity.status === "EXPIRED" ? "ghost" : "primary"}
-          className={styles.actionButton}
-          disabled={isDisabled}
-          onClick={handleActionButton}
-        >
-          <statusConfig.buttonIcon className={styles.buttonIcon} />
-          {buttonText}
-        </Button>
+        <div className={styles.buttonGroup}>
+          {hasAttemptedActivity && (
+            <Button
+              variant="secondary"
+              className={styles.secondaryButton}
+              onClick={handleViewLastAttempt}
+            >
+              Ver último intento
+            </Button>
+          )}
+
+          <Button
+            variant={
+              activity.status === "EXPIRED" && activity.remainingAttempts > 0
+                ? "ghost"
+                : "primary"
+            }
+            className={styles.actionButton}
+            disabled={isDisabled}
+            onClick={handleActionButton}
+          >
+            <ButtonIcon className={styles.buttonIcon} />
+            {buttonText}
+          </Button>
+        </div>
       </div>
 
       {/* Puntuación */}

--- a/src/student/components/studentActivitiesViewComponents/activityRow/ActivityRow.tsx
+++ b/src/student/components/studentActivitiesViewComponents/activityRow/ActivityRow.tsx
@@ -16,9 +16,14 @@ import styles from "./ActivityRow.module.css";
 interface ActivityRowProps {
   activity: ActivityUI;
   onStart?: (activityId: string) => void;
+  onViewResults?: (activityId: string) => void;
 }
 
-const ActivityRow: React.FC<ActivityRowProps> = ({ activity, onStart }) => {
+const ActivityRow: React.FC<ActivityRowProps> = ({
+  activity,
+  onStart,
+  onViewResults,
+}) => {
   const statusConfig = getActivityStatusConfig(activity.status);
   const isDisabled =
     (activity.status === "CREATED" || activity.noAttempts) &&
@@ -30,7 +35,13 @@ const ActivityRow: React.FC<ActivityRowProps> = ({ activity, onStart }) => {
   const subjectColor = getSubjectColor(activity.subjectName);
 
   const handleActionButton = async () => {
-    if (activity.status === "PUBLISHED" && !activity.noAttempts && onStart) {
+    if (activity.status === "APPROVED" && onViewResults) {
+      onViewResults(activity.id);
+    } else if (
+      activity.status === "PUBLISHED" &&
+      !activity.noAttempts &&
+      onStart
+    ) {
       onStart(activity.id);
     }
   };

--- a/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.module.css
+++ b/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.module.css
@@ -1,0 +1,202 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.detailsCard {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.detailsCard:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: white;
+  margin: 0;
+}
+
+.titleIcon {
+  font-size: 1.25rem;
+}
+
+.viewToggle {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.viewToggle:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: black;
+  transform: translateY(-1px);
+}
+
+.descriptionSection {
+  background: rgba(255, 255, 255, 0.05);
+  margin-bottom: 1rem;
+}
+
+.descriptionIcon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  color: white;
+}
+
+.detailsGrid {
+  display: grid;
+  gap: 1rem;
+  transition: all 0.3s ease;
+}
+
+.detailsGrid.vertical {
+  grid-template-columns: 1fr;
+}
+
+.detailsGrid.horizontal {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.detailItem {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all 0.3s ease;
+}
+
+.detailItem:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+}
+
+.detailContent {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.detailIcon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+  color: white;
+}
+
+.detailContent > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.label {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.value {
+  font-weight: 600;
+  color: white;
+  font-size: 1rem;
+}
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.skeletonCard {
+  height: 200px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .detailsCard {
+    padding: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.1rem;
+  }
+
+  .viewToggle {
+    align-self: flex-end;
+    font-size: 0.8rem;
+    padding: 0.4rem 0.8rem;
+  }
+
+  .descriptionSection {
+    padding: 1rem;
+  }
+
+  .detailsGrid.horizontal {
+    grid-template-columns: 1fr;
+  }
+
+  .detailsGrid {
+    gap: 0.75rem;
+  }
+
+  .detailItem {
+    padding: 0.75rem;
+  }
+
+  .detailContent {
+    gap: 0.5rem;
+  }
+}

--- a/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.module.css
+++ b/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.module.css
@@ -37,10 +37,6 @@
   margin: 0;
 }
 
-.titleIcon {
-  font-size: 1.25rem;
-}
-
 .viewToggle {
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
@@ -109,7 +105,6 @@
 .detailIcon {
   font-size: 1.5rem;
   flex-shrink: 0;
-  color: white;
 }
 
 .detailContent > div {
@@ -131,6 +126,20 @@
   font-weight: 600;
   color: white;
   font-size: 1rem;
+}
+
+.subjectIcon {
+  color: white;
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.3));
+}
+
+.difficultyGlow {
+  filter: drop-shadow(0 0 8px currentColor);
+}
+
+.maxTimeIcon {
+  color: #e2e4e9;
+  filter: drop-shadow(0 0 8px rgba(226, 221, 221, 0.4));
 }
 
 .skeleton {

--- a/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.tsx
+++ b/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.tsx
@@ -8,8 +8,10 @@ import {
   FaClock,
 } from "react-icons/fa";
 import type { CurrentActivityInterface } from "../../../types/Activity.type";
-import { Button, Card } from "@/shared";
+import { Button, Card, Badge } from "@/shared";
 import { useViewToggle } from "../../../hooks/useViewToggle";
+import { getSubjectColor } from "@/shared";
+import { getDifficultyColor } from "@/shared/constants/difficulty.constants";
 import styles from "./ActivityResultsDetails.module.css";
 
 interface ActivityResultsDetailsProps {
@@ -21,24 +23,41 @@ const ActivityResultsDetails: React.FC<ActivityResultsDetailsProps> = ({
 }) => {
   const { isHorizontal, toggleView, viewMode } = useViewToggle(true);
 
+  const subjectColor = getSubjectColor(activity.subject.name);
+  const difficultyColor = getDifficultyColor(activity.difficulty);
+
   const detailItems = [
     {
       id: "subject",
       icon: FaBook,
       label: "Materia",
-      value: activity.subject.name,
+      value: (
+        <Badge
+          style={{
+            backgroundColor: subjectColor.bg,
+            color: subjectColor.text,
+          }}
+          className={styles.stateBadge}
+        >
+          {activity.subject.name}
+        </Badge>
+      ),
+      iconColorClass: styles.subjectIcon,
     },
     {
       id: "difficulty",
       icon: FaSignal,
       label: "Dificultad",
-      value: activity.difficulty,
+      value: difficultyColor.label,
+      iconColorStyle: { color: difficultyColor.text },
+      iconGlowClass: styles.difficultyGlow,
     },
     {
       id: "maxTime",
       icon: FaClock,
       label: "Tiempo máximo",
       value: `${activity.maxTime} minutos`,
+      iconColorClass: styles.maxTimeIcon,
     },
   ];
 
@@ -47,7 +66,12 @@ const ActivityResultsDetails: React.FC<ActivityResultsDetailsProps> = ({
     return (
       <div key={item.id} className={styles.detailItem}>
         <div className={styles.detailContent}>
-          <IconComponent className={styles.detailIcon} />
+          <IconComponent
+            className={`${styles.detailIcon} ${item.iconColorClass || ""} ${
+              item.iconGlowClass || ""
+            }`}
+            style={item.iconColorStyle || {}}
+          />
           <div>
             <span className={styles.label}>{item.label}</span>
             <span className={styles.value}>{item.value}</span>

--- a/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.tsx
+++ b/src/student/components/studentActivityResults/activityResultsDetails/ActivityResultsDetails.tsx
@@ -1,0 +1,103 @@
+import { motion } from "framer-motion";
+import {
+  FaFile,
+  FaColumns,
+  FaList,
+  FaBook,
+  FaSignal,
+  FaClock,
+} from "react-icons/fa";
+import type { CurrentActivityInterface } from "../../../types/Activity.type";
+import { Button, Card } from "@/shared";
+import { useViewToggle } from "../../../hooks/useViewToggle";
+import styles from "./ActivityResultsDetails.module.css";
+
+interface ActivityResultsDetailsProps {
+  activity: CurrentActivityInterface;
+}
+
+const ActivityResultsDetails: React.FC<ActivityResultsDetailsProps> = ({
+  activity,
+}) => {
+  const { isHorizontal, toggleView, viewMode } = useViewToggle(true);
+
+  const detailItems = [
+    {
+      id: "subject",
+      icon: FaBook,
+      label: "Materia",
+      value: activity.subject.name,
+    },
+    {
+      id: "difficulty",
+      icon: FaSignal,
+      label: "Dificultad",
+      value: activity.difficulty,
+    },
+    {
+      id: "maxTime",
+      icon: FaClock,
+      label: "Tiempo máximo",
+      value: `${activity.maxTime} minutos`,
+    },
+  ];
+
+  const renderDetailItem = (item: any) => {
+    const IconComponent = item.icon;
+    return (
+      <div key={item.id} className={styles.detailItem}>
+        <div className={styles.detailContent}>
+          <IconComponent className={styles.detailIcon} />
+          <div>
+            <span className={styles.label}>{item.label}</span>
+            <span className={styles.value}>{item.value}</span>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={styles.container}
+    >
+      <Card className={styles.detailsCard}>
+        <div className={styles.header}>
+          <h3 className={styles.sectionTitle}>Información de la Actividad</h3>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleView}
+            className={styles.viewToggle}
+          >
+            {isHorizontal ? <FaList /> : <FaColumns />}
+          </Button>
+        </div>
+
+        {activity.description && (
+          <div className={styles.descriptionSection}>
+            <div className={styles.detailItem}>
+              <div className={styles.detailContent}>
+                <FaFile className={styles.descriptionIcon} />
+                <div>
+                  <span className={styles.label}>
+                    Descripción de la actividad
+                  </span>
+                  <span className={styles.value}>{activity.description}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className={`${styles.detailsGrid} ${styles[viewMode]}`}>
+          {detailItems.map((item) => renderDetailItem(item))}
+        </div>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default ActivityResultsDetails;

--- a/src/student/components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback.module.css
+++ b/src/student/components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback.module.css
@@ -1,0 +1,119 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feedbackCard {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.feedbackCard:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: white;
+  margin: 0;
+}
+
+.feedbackContent {
+  display: flex;
+  flex-direction: column;
+}
+
+.detailItem {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all 0.3s ease;
+}
+
+.detailItem:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+}
+
+.detailContent {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.detailIcon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.detailContent > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.label {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.value {
+  font-weight: 600;
+  color: white;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.teacherComments {
+  color: rgba(255, 255, 255, 0.6);
+  font-style: italic;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .feedbackCard {
+    padding: 1rem;
+  }
+
+  .header {
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.1rem;
+  }
+
+  .detailItem {
+    padding: 0.75rem;
+  }
+
+  .detailContent {
+    gap: 0.5rem;
+  }
+}

--- a/src/student/components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback.tsx
+++ b/src/student/components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback.tsx
@@ -1,0 +1,47 @@
+import { motion } from "framer-motion";
+import { FcComments } from "react-icons/fc";
+import { Card } from "@/shared";
+import styles from "./ActivityResultsFeedback.module.css";
+
+interface ActivityResultsFeedbackProps {
+  teacherComment?: string | null;
+}
+
+const ActivityResultsFeedback: React.FC<ActivityResultsFeedbackProps> = ({
+  teacherComment,
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={styles.container}
+    >
+      <Card className={styles.feedbackCard}>
+        <div className={styles.header}>
+          <h3 className={styles.sectionTitle}>Comentarios del Docente</h3>
+        </div>
+
+        <div className={styles.feedbackContent}>
+          <div className={styles.detailItem}>
+            <div className={styles.detailContent}>
+              <FcComments className={styles.detailIcon} />
+              <div>
+                <span className={styles.label}>Retroalimentación</span>
+                <span
+                  className={`${styles.value} ${
+                    !teacherComment ? styles.teacherComments : ""
+                  }`}
+                >
+                  {teacherComment ||
+                    "El docente no ha realizado comentarios aún"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default ActivityResultsFeedback;

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
@@ -1,113 +1,338 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 2rem;
 }
 
-.detailsCard {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 16px;
-  padding: 1.5rem;
-  transition: all 0.3s ease;
-}
-
-.detailsCard:hover {
-  background: rgba(255, 255, 255, 0.15);
-  border-color: rgba(255, 255, 255, 0.3);
-}
-
-.header {
+.statusHeader {
+  padding: 2rem;
+  border-radius: 24px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+  gap: 2rem;
+  position: relative;
+  overflow: hidden;
 }
 
-.sectionTitle {
+.statusHeader::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  opacity: 0.1;
+  background: radial-gradient(
+    circle at top right,
+    rgba(255, 255, 255, 0.3),
+    transparent 50%
+  );
+}
+
+.statusHeader.approved {
+  background: linear-gradient(
+    135deg,
+    rgba(52, 211, 153, 0.25),
+    rgba(16, 185, 129, 0.25)
+  );
+  border-color: rgba(52, 211, 153, 0.5);
+}
+
+.statusHeader.disapproved {
+  background: linear-gradient(
+    135deg,
+    rgba(248, 113, 113, 0.25),
+    rgba(239, 68, 68, 0.25)
+  );
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.statusHeader.pending {
+  background: linear-gradient(
+    135deg,
+    rgba(251, 191, 36, 0.25),
+    rgba(245, 158, 11, 0.25)
+  );
+  border-color: rgba(251, 191, 36, 0.4);
+}
+
+.statusLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.statusTitle {
+  font-size: 2rem;
+  font-weight: 800;
+  color: white;
+  margin: 0;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.stateBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 50px;
+  white-space: nowrap;
+  width: fit-content;
+}
+
+.statusRight {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  position: relative;
+  z-index: 1;
+}
+
+.rewardBox {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(5px);
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.trophyIcon {
+  color: #fbbf24;
+  filter: drop-shadow(0 0 15px rgba(251, 191, 36, 0.5));
+  font-size: 2.5rem;
+}
+
+.rewardContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rewardLabel {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.rewardValueWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.coinIcon {
+  color: #f59e0b;
+  filter: drop-shadow(0 0 10px rgba(245, 158, 11, 0.4));
+  font-size: 1.5rem;
+  animation: bounce 1.5s ease-in-out infinite;
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
+}
+
+.rewardNumber {
+  font-size: 2rem;
+  font-weight: 900;
+  color: white;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.scoreBox {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(5px);
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.scoreStarIcon {
+  color: #fbbf24;
+  filter: drop-shadow(0 0 15px rgba(251, 191, 36, 0.5));
+  font-size: 2.5rem;
+}
+
+.scoreContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.scoreLabel {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.gaugeContainer {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.gaugeBars {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 40px;
+}
+
+.gaugeBar {
+  width: 4px;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+  transform-origin: bottom;
+  transition: all 0.3s ease;
+}
+
+.gaugeBarFilled {
+  background: linear-gradient(to top, #34d399, #10b981);
+  box-shadow: 0 0 8px rgba(52, 211, 153, 0.5);
+}
+
+.scoreNumber {
+  font-size: 2rem;
+  font-weight: 900;
+  color: white;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  min-width: 60px;
+}
+
+.metricBox {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(5px);
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.metricBoxIcon {
+  color: rgba(255, 255, 255, 0.9);
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.3));
+  font-size: 2rem;
+}
+
+.metricBoxContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metricBoxLabel {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.metricBoxValue {
   font-size: 1.25rem;
   font-weight: 700;
   color: white;
-  margin: 0;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-.titleIcon {
-  font-size: 1.25rem;
-}
-
-.viewToggle {
+.secondaryStatsCard {
   background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  padding: 2rem;
+}
+
+.sectionTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
   color: white;
-  border-radius: 8px;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  white-space: nowrap;
+  margin: 0 0 1.5rem 0;
+  text-align: center;
 }
 
-.viewToggle:hover {
-  background: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.3);
-  color: black;
-  transform: translateY(-1px);
-}
-
-.detailsGrid {
+.secondaryStatsGrid {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.secondaryStatItem {
+  display: flex;
+  align-items: center;
   gap: 1rem;
-  transition: all 0.3s ease;
-}
-
-.detailsGrid.vertical {
-  grid-template-columns: 1fr;
-}
-
-.detailsGrid.horizontal {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.detailItem {
   background: rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 1rem;
+  border-radius: 16px;
+  padding: 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   transition: all 0.3s ease;
 }
 
-.detailItem:hover {
+.secondaryStatItem:hover {
   background: rgba(255, 255, 255, 0.1);
   border-color: rgba(255, 255, 255, 0.2);
   transform: translateY(-2px);
 }
 
-.detailContent {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.detailIcon {
-  font-size: 1.5rem;
+.secondaryStatIcon {
   flex-shrink: 0;
 }
 
-.detailContent > div {
+.detailIcon {
+  font-size: 2rem;
+}
+
+.secondaryStatItem:has(.completedTimeValue) .detailIcon {
+  color: #e2e4e9;
+  filter: drop-shadow(0 0 8px rgba(226, 221, 221, 0.4));
+}
+
+.secondaryStatItem:has(.correctValue) .detailIcon {
+  color: #34d399;
+  filter: drop-shadow(0 0 8px rgba(52, 211, 153, 0.4));
+}
+
+.secondaryStatItem:has(.incorrectValue) .detailIcon {
+  color: #f87171;
+  filter: drop-shadow(0 0 8px rgba(248, 113, 113, 0.4));
+}
+
+.secondaryStatItem:has(.unansweredValue) .detailIcon {
+  color: #9ca3af;
+}
+
+.secondaryStatContent {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   flex: 1;
 }
 
-.label {
+.secondaryStatLabel {
   font-weight: 500;
   color: rgba(255, 255, 255, 0.7);
   font-size: 0.85rem;
@@ -115,137 +340,69 @@
   letter-spacing: 0.5px;
 }
 
-.value {
-  font-weight: 600;
+.secondaryStatValue {
+  font-weight: 700;
   color: white;
-  font-size: 1rem;
-}
-
-.detailItem:has(.rewardValue) .detailIcon {
-  color: #fbbf24;
-  filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.4));
-}
-
-.detailItem:has(.scoreValue) .detailIcon {
-  color: #fac68b;
-  filter: drop-shadow(0 0 8px rgba(250, 224, 139, 0.4));
-}
-
-.detailItem:has(.completedTimeValue) .detailIcon {
-  color: #e2e4e9;
-  filter: drop-shadow(0 0 8px rgba(226, 221, 221, 0.4));
-}
-
-.detailItem:has(.attemptsValue) .detailIcon {
-  color: #fc96cb;
-  filter: drop-shadow(0 0 8px rgba(255, 140, 199, 0.4));
-}
-
-.detailItem:has(.correctValue) .detailIcon {
-  color: #34d399;
-  filter: drop-shadow(0 0 8px rgba(52, 211, 153, 0.4));
-}
-
-.detailItem:has(.incorrectValue) .detailIcon {
-  color: #f87171;
-  filter: drop-shadow(0 0 8px rgba(248, 113, 113, 0.4));
-}
-
-.detailItem:has(.unansweredValue) .detailIcon {
-  color: #9ca3af;
-}
-
-.stateBadge {
-  display: inline-flex;
-  align-items: center;
-  margin-top: 0.25rem;
-}
-
-.rewardValue {
-  color: white;
-}
-
-.scoreValue {
-  color: white;
-}
-
-.correctValue {
-  color: white;
-}
-
-.incorrectValue {
-  color: white;
-}
-
-.unansweredValue {
-  color: white;
-}
-
-.teacherComments {
-  color: rgba(255, 255, 255, 0.6);
-  font-style: italic;
-}
-
-.skeleton {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.skeletonCard {
-  height: 300px;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 16px;
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
+  font-size: 1.5rem;
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
-  .detailsCard {
-    padding: 1rem;
-  }
-
-  .header {
+@media (max-width: 1024px) {
+  .statusHeader {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .statusRight {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .statusHeader {
+    padding: 1.5rem;
+  }
+
+  .statusTitle {
+    font-size: 1.5rem;
+  }
+
+  .statusRight {
+    flex-direction: column;
     gap: 1rem;
+    width: 100%;
+  }
+
+  .rewardBox,
+  .metricBox,
+  .scoreBox {
+    width: 100%;
+  }
+
+  .secondaryStatsCard {
+    padding: 1.5rem;
   }
 
   .sectionTitle {
-    font-size: 1.1rem;
+    font-size: 1.25rem;
   }
 
-  .viewToggle {
-    align-self: flex-end;
-    font-size: 0.8rem;
-    padding: 0.4rem 0.8rem;
-  }
-
-  .detailsGrid.horizontal {
+  .secondaryStatsGrid {
     grid-template-columns: 1fr;
+    gap: 1rem;
   }
 
-  .detailsGrid {
-    gap: 0.75rem;
+  .secondaryStatItem {
+    padding: 1rem;
   }
 
-  .detailItem {
-    padding: 0.75rem;
+  .detailIcon {
+    font-size: 1.5rem;
   }
 
-  .detailContent {
-    gap: 0.5rem;
+  .secondaryStatValue {
+    font-size: 1.25rem;
   }
 }

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
@@ -135,17 +135,6 @@
   color: #f59e0b;
   filter: drop-shadow(0 0 10px rgba(245, 158, 11, 0.4));
   font-size: 1.5rem;
-  animation: bounce 1.5s ease-in-out infinite;
-}
-
-@keyframes bounce {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-5px);
-  }
 }
 
 .rewardNumber {

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
@@ -256,12 +256,40 @@
   padding: 2rem;
 }
 
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  position: relative;
+}
+
+.sectionHeader::before,
+.sectionHeader::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.15),
+    rgba(255, 255, 255, 0.4)
+  );
+}
+
+.sectionHeader::after {
+  background: linear-gradient(
+    to left,
+    rgba(255, 255, 255, 0.15),
+    rgba(255, 255, 255, 0.4)
+  );
+}
+
 .sectionTitle {
   font-size: 1.5rem;
   font-weight: 700;
   color: white;
-  margin: 0 0 1.5rem 0;
-  text-align: center;
+  margin: 0 1.25rem;
+  white-space: nowrap;
 }
 
 .secondaryStatsGrid {

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
@@ -127,13 +127,18 @@
 }
 
 .detailItem:has(.scoreValue) .detailIcon {
-  color: #a78bfa;
-  filter: drop-shadow(0 0 8px rgba(167, 139, 250, 0.4));
+  color: #fac68b;
+  filter: drop-shadow(0 0 8px rgba(250, 224, 139, 0.4));
 }
 
 .detailItem:has(.completedTimeValue) .detailIcon {
   color: #e2e4e9;
-  filter: drop-shadow(0 0 8px rgba(167, 139, 250, 0.4));
+  filter: drop-shadow(0 0 8px rgba(226, 221, 221, 0.4));
+}
+
+.detailItem:has(.attemptsValue) .detailIcon {
+  color: #fc96cb;
+  filter: drop-shadow(0 0 8px rgba(255, 140, 199, 0.4));
 }
 
 .detailItem:has(.correctValue) .detailIcon {

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.module.css
@@ -1,0 +1,246 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.detailsCard {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.detailsCard:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: white;
+  margin: 0;
+}
+
+.titleIcon {
+  font-size: 1.25rem;
+}
+
+.viewToggle {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.viewToggle:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: black;
+  transform: translateY(-1px);
+}
+
+.detailsGrid {
+  display: grid;
+  gap: 1rem;
+  transition: all 0.3s ease;
+}
+
+.detailsGrid.vertical {
+  grid-template-columns: 1fr;
+}
+
+.detailsGrid.horizontal {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.detailItem {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all 0.3s ease;
+}
+
+.detailItem:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+}
+
+.detailContent {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.detailIcon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.detailContent > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.label {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.value {
+  font-weight: 600;
+  color: white;
+  font-size: 1rem;
+}
+
+.detailItem:has(.rewardValue) .detailIcon {
+  color: #fbbf24;
+  filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.4));
+}
+
+.detailItem:has(.scoreValue) .detailIcon {
+  color: #a78bfa;
+  filter: drop-shadow(0 0 8px rgba(167, 139, 250, 0.4));
+}
+
+.detailItem:has(.completedTimeValue) .detailIcon {
+  color: #e2e4e9;
+  filter: drop-shadow(0 0 8px rgba(167, 139, 250, 0.4));
+}
+
+.detailItem:has(.correctValue) .detailIcon {
+  color: #34d399;
+  filter: drop-shadow(0 0 8px rgba(52, 211, 153, 0.4));
+}
+
+.detailItem:has(.incorrectValue) .detailIcon {
+  color: #f87171;
+  filter: drop-shadow(0 0 8px rgba(248, 113, 113, 0.4));
+}
+
+.detailItem:has(.unansweredValue) .detailIcon {
+  color: #9ca3af;
+}
+
+.stateBadge {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.25rem;
+}
+
+.rewardValue {
+  color: white;
+}
+
+.scoreValue {
+  color: white;
+}
+
+.correctValue {
+  color: white;
+}
+
+.incorrectValue {
+  color: white;
+}
+
+.unansweredValue {
+  color: white;
+}
+
+.teacherComments {
+  color: rgba(255, 255, 255, 0.6);
+  font-style: italic;
+}
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.skeletonCard {
+  height: 300px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .detailsCard {
+    padding: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .sectionTitle {
+    font-size: 1.1rem;
+  }
+
+  .viewToggle {
+    align-self: flex-end;
+    font-size: 0.8rem;
+    padding: 0.4rem 0.8rem;
+  }
+
+  .detailsGrid.horizontal {
+    grid-template-columns: 1fr;
+  }
+
+  .detailsGrid {
+    gap: 0.75rem;
+  }
+
+  .detailItem {
+    padding: 0.75rem;
+  }
+
+  .detailContent {
+    gap: 0.5rem;
+  }
+}

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
@@ -1,0 +1,183 @@
+import { motion } from "framer-motion";
+import {
+  FaColumns,
+  FaList,
+  FaTrophy,
+  FaCheckCircle,
+  FaTimesCircle,
+  FaQuestionCircle,
+  FaClock,
+} from "react-icons/fa";
+import { FcStatistics, FcComments } from "react-icons/fc";
+import type { IconType } from "react-icons";
+import type {
+  ActivityResultsResponseInterface,
+  CurrentActivityInterface,
+} from "../../../types/Activity.type";
+import type { GameType } from "../../../../shared/types/Games.type";
+import { Button, Card, Badge } from "@/shared";
+import {
+  formatResultState,
+  formatCompletedTime,
+  getStatsLabels,
+  shouldShowStat,
+  shouldShowScore,
+} from "../../../utils/activityResults.utils";
+import { useViewToggle } from "../../../hooks/useViewToggle";
+import styles from "./ActivityResultsStats.module.css";
+
+interface ActivityResultsStatsProps {
+  results: ActivityResultsResponseInterface;
+  activity: CurrentActivityInterface;
+}
+
+interface StatItem {
+  id: string;
+  icon: IconType;
+  label: string;
+  value: React.ReactElement | string;
+  className?: string;
+}
+
+const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
+  results,
+  activity,
+}) => {
+  const { isHorizontal, toggleView, viewMode } = useViewToggle(true);
+  const stateInfo = formatResultState(results.state);
+  const gameType = activity.name.toLowerCase() as GameType;
+  const statsLabels = getStatsLabels(gameType);
+
+  const statsItems: StatItem[] = [
+    {
+      id: "state",
+      icon: FcStatistics,
+      label: "Resultado",
+      value: (
+        <Badge variant={stateInfo.variant} className={styles.stateBadge}>
+          {stateInfo.label}
+        </Badge>
+      ),
+    },
+    {
+      id: "reward",
+      icon: FaTrophy,
+      label: "Recompensa obtenida",
+      value: `${results.reward} monedas`,
+      className: styles.rewardValue,
+    },
+  ];
+
+  if (shouldShowScore(gameType)) {
+    statsItems.push({
+      id: "score",
+      icon: FcStatistics,
+      label: "Puntuación",
+      value: `${results.score} puntos`,
+      className: styles.scoreValue,
+    });
+  }
+
+  statsItems.push(
+    {
+      id: "completedTime",
+      icon: FaClock,
+      label: "Tiempo de realización",
+      value: formatCompletedTime(results.completedTimeInSeconds),
+      className: styles.completedTimeValue,
+    },
+    {
+      id: "attempts",
+      icon: FcStatistics,
+      label: "Intentos utilizados",
+      value: `${results.attempts} de ${activity.attempts}`,
+    }
+  );
+
+  if (shouldShowStat(gameType, "correctAnswers")) {
+    statsItems.push({
+      id: "correctAnswers",
+      icon: FaCheckCircle,
+      label: statsLabels.correctAnswers!,
+      value: `${results.correctAnswers}`,
+      className: styles.correctValue,
+    });
+  }
+
+  if (shouldShowStat(gameType, "incorrectAnswers")) {
+    statsItems.push({
+      id: "incorrectAnswers",
+      icon: FaTimesCircle,
+      label: statsLabels.incorrectAnswers!,
+      value: `${results.incorrectAnswers}`,
+      className: styles.incorrectValue,
+    });
+  }
+
+  if (shouldShowStat(gameType, "unanswered")) {
+    statsItems.push({
+      id: "unanswered",
+      icon: FaQuestionCircle,
+      label: statsLabels.unanswered!,
+      value: `${results.unanswered}`,
+      className: styles.unansweredValue,
+    });
+  }
+
+  const renderStatItem = (item: StatItem) => {
+    const IconComponent = item.icon;
+    return (
+      <div key={item.id} className={styles.detailItem}>
+        <div className={styles.detailContent}>
+          <IconComponent className={styles.detailIcon} />
+          <div>
+            <span className={styles.label}>{item.label}</span>
+            <span className={`${styles.value} ${item.className || ""}`}>
+              {item.value}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={styles.container}
+    >
+      <Card className={styles.detailsCard}>
+        <div className={styles.header}>
+          <h3 className={styles.sectionTitle}>Resultados de la Actividad</h3>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleView}
+            className={styles.viewToggle}
+          >
+            {isHorizontal ? <FaList /> : <FaColumns />}
+          </Button>
+        </div>
+
+        <div className={`${styles.detailsGrid} ${styles[viewMode]}`}>
+          {statsItems.map((item) => renderStatItem(item))}
+
+          <div className={styles.detailItem}>
+            <div className={styles.detailContent}>
+              <FcComments className={styles.detailIcon} />
+              <div>
+                <span className={styles.label}>Comentarios del docente</span>
+                <span className={`${styles.value} ${styles.teacherComments}`}>
+                  El docente no ha realizado comentarios aún
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default ActivityResultsStats;

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
@@ -1,7 +1,6 @@
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import {
-  FaColumns,
-  FaList,
   FaTrophy,
   FaStar,
   FaCheckCircle,
@@ -9,15 +8,16 @@ import {
   FaTimesCircle,
   FaQuestionCircle,
   FaClock,
+  FaCoins,
 } from "react-icons/fa";
-import { FcStatistics } from "react-icons/fc";
 import type { IconType } from "react-icons";
 import type {
   ActivityResultsResponseInterface,
   CurrentActivityInterface,
 } from "../../../types/Activity.type";
 import type { GameType } from "../../../../shared/types/Games.type";
-import { Button, Card, Badge } from "@/shared";
+import { Card, Badge, useCountUp } from "@/shared";
+import { useActivityStudent } from "../../../hooks/useActivityStudentAPI";
 import {
   formatResultState,
   formatCompletedTime,
@@ -25,7 +25,6 @@ import {
   shouldShowStat,
   shouldShowScore,
 } from "../../../utils/activityResults.utils";
-import { useViewToggle } from "../../../hooks/useViewToggle";
 import styles from "./ActivityResultsStats.module.css";
 
 interface ActivityResultsStatsProps {
@@ -38,6 +37,7 @@ interface StatItem {
   icon: IconType;
   label: string;
   value: React.ReactElement | string;
+  numericValue?: number;
   className?: string;
 }
 
@@ -45,104 +45,159 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
   results,
   activity,
 }) => {
-  const { isHorizontal, toggleView, viewMode } = useViewToggle(true);
+  const [animationPhase, setAnimationPhase] = useState(0);
+  const { currentActivityAttemptInfo } = useActivityStudent();
+
+  useEffect(() => {
+    setAnimationPhase(1);
+  }, []);
+
+  const animatedReward = useCountUp(results.reward, animationPhase, {
+    steps: 50,
+    interval: 50,
+  });
+
   const stateInfo = formatResultState(results.state);
   const gameType = activity.name.toLowerCase() as GameType;
   const statsLabels = getStatsLabels(gameType);
+  const isApproved = results.state === "APPROVED";
 
-  const statsItems: StatItem[] = [
-    {
-      id: "state",
-      icon: FcStatistics,
-      label: "Estado",
-      value: (
-        <Badge variant={stateInfo.variant} className={styles.stateBadge}>
-          {stateInfo.label}
-        </Badge>
-      ),
-    },
-    {
-      id: "reward",
-      icon: FaTrophy,
-      label: "Recompensa obtenida",
-      value: `${results.reward} monedas`,
-      className: styles.rewardValue,
-    },
-  ];
-
-  if (shouldShowScore(gameType)) {
-    statsItems.push({
-      id: "score",
-      icon: FaStar,
-      label: "Puntuación",
-      value: `${results.score}/100 puntos`,
-      className: styles.scoreValue,
-    });
-  }
-
-  statsItems.push(
-    {
-      id: "completedTime",
-      icon: FaClock,
-      label: "Tiempo de realización",
-      value: formatCompletedTime(results.completedTimeInSeconds),
-      className: styles.completedTimeValue,
-    },
-    {
-      id: "attempts",
-      icon: FaClipboardCheck,
-      label: "Intentos utilizados",
-      value: `${results.attempts} de ${activity.attempts}`,
-      className: styles.attemptsValue,
+  const getStatusMessage = () => {
+    if (isApproved) {
+      return results.score >= 80 ? "¡Excelente trabajo!" : "¡Bien hecho!";
     }
-  );
 
-  if (shouldShowStat(gameType, "correctAnswers")) {
-    statsItems.push({
-      id: "correctAnswers",
-      icon: FaCheckCircle,
-      label: statsLabels.correctAnswers!,
-      value: `${results.correctAnswers}`,
-      className: styles.correctValue,
-    });
-  }
+    const remainingAttempts =
+      currentActivityAttemptInfo?.remainingAttempts || 0;
+    if (remainingAttempts > 0) {
+      return `Sigue intentando`;
+    }
+    return "Actividad desaprobada";
+  };
 
-  if (shouldShowStat(gameType, "incorrectAnswers")) {
-    statsItems.push({
-      id: "incorrectAnswers",
-      icon: FaTimesCircle,
-      label: statsLabels.incorrectAnswers!,
-      value: `${results.incorrectAnswers}`,
-      className: styles.incorrectValue,
-    });
-  }
+  const getDetailsTitle = () => {
+    return isApproved ? "Detalle de realización" : "Detalle del último intento";
+  };
 
-  if (shouldShowStat(gameType, "unanswered")) {
-    statsItems.push({
-      id: "unanswered",
-      icon: FaQuestionCircle,
-      label: statsLabels.unanswered!,
-      value: `${results.unanswered}`,
-      className: styles.unansweredValue,
-    });
-  }
-
-  const renderStatItem = (item: StatItem) => {
-    const IconComponent = item.icon;
+  const renderRightMetric = (
+    icon: IconType,
+    label: string,
+    value: string | number
+  ) => {
+    const IconComponent = icon;
     return (
-      <div key={item.id} className={styles.detailItem}>
-        <div className={styles.detailContent}>
-          <IconComponent className={styles.detailIcon} />
-          <div>
-            <span className={styles.label}>{item.label}</span>
-            <span className={`${styles.value} ${item.className || ""}`}>
-              {item.value}
-            </span>
+      <div className={styles.metricBox}>
+        <IconComponent className={styles.metricBoxIcon} />
+        <div className={styles.metricBoxContent}>
+          <span className={styles.metricBoxLabel}>{label}</span>
+          <span className={styles.metricBoxValue}>{value}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderScoreGauge = () => {
+    const score = results.score || 0;
+    const totalBars = 20;
+    const filledBars = Math.round((score / 100) * totalBars);
+
+    return (
+      <div className={styles.scoreBox}>
+        <FaStar className={styles.scoreStarIcon} />
+        <div className={styles.scoreContent}>
+          <span className={styles.scoreLabel}>Puntuación Obtenida</span>
+          <div className={styles.gaugeContainer}>
+            <div className={styles.gaugeBars}>
+              {Array.from({ length: totalBars }).map((_, index) => (
+                <motion.div
+                  key={index}
+                  className={`${styles.gaugeBar} ${
+                    index < filledBars ? styles.gaugeBarFilled : ""
+                  }`}
+                  initial={{ scaleY: 0 }}
+                  animate={{ scaleY: index < filledBars ? 1 : 0.3 }}
+                  transition={{
+                    duration: 0.3,
+                    delay: 0.5 + index * 0.05,
+                    ease: "easeOut",
+                  }}
+                />
+              ))}
+            </div>
+            <span className={styles.scoreNumber}>{score}%</span>
           </div>
         </div>
       </div>
     );
   };
+
+  const secondaryStats: StatItem[] = [];
+
+  secondaryStats.push({
+    id: "completedTime",
+    icon: FaClock,
+    label: "Tiempo empleado",
+    value: formatCompletedTime(results.completedTimeInSeconds),
+    className: styles.completedTimeValue,
+  });
+
+  if (shouldShowStat(gameType, "correctAnswers")) {
+    secondaryStats.push({
+      id: "correctAnswers",
+      icon: FaCheckCircle,
+      label: statsLabels.correctAnswers!,
+      value: `${results.correctAnswers}`,
+      numericValue: results.correctAnswers,
+      className: styles.correctValue,
+    });
+  }
+
+  if (shouldShowStat(gameType, "incorrectAnswers")) {
+    secondaryStats.push({
+      id: "incorrectAnswers",
+      icon: FaTimesCircle,
+      label: statsLabels.incorrectAnswers!,
+      value: `${results.incorrectAnswers}`,
+      numericValue: results.incorrectAnswers,
+      className: styles.incorrectValue,
+    });
+  }
+
+  if (shouldShowStat(gameType, "unanswered")) {
+    secondaryStats.push({
+      id: "unanswered",
+      icon: FaQuestionCircle,
+      label: statsLabels.unanswered!,
+      value: `${results.unanswered}`,
+      numericValue: results.unanswered,
+      className: styles.unansweredValue,
+    });
+  }
+
+  const renderSecondaryStat = (item: StatItem, index: number) => {
+    const IconComponent = item.icon;
+    return (
+      <motion.div
+        key={item.id}
+        className={styles.secondaryStatItem}
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ delay: 0.4 + index * 0.1 }}
+      >
+        <div className={styles.secondaryStatIcon}>
+          <IconComponent className={styles.detailIcon} />
+        </div>
+        <div className={styles.secondaryStatContent}>
+          <span className={styles.secondaryStatLabel}>{item.label}</span>
+          <span className={`${styles.secondaryStatValue} ${item.className}`}>
+            {item.value}
+          </span>
+        </div>
+      </motion.div>
+    );
+  };
+
+  const remainingAttempts = currentActivityAttemptInfo?.remainingAttempts || 0;
 
   return (
     <motion.div
@@ -150,23 +205,68 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
       animate={{ opacity: 1, y: 0 }}
       className={styles.container}
     >
-      <Card className={styles.detailsCard}>
-        <div className={styles.header}>
-          <h3 className={styles.sectionTitle}>Resultados de la Actividad</h3>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={toggleView}
-            className={styles.viewToggle}
-          >
-            {isHorizontal ? <FaList /> : <FaColumns />}
-          </Button>
+      <motion.div
+        className={`${styles.statusHeader} ${
+          styles[results.state.toLowerCase()]
+        }`}
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.5 }}
+      >
+        <div className={styles.statusLeft}>
+          <h2 className={styles.statusTitle}>{getStatusMessage()}</h2>
+          <Badge variant={stateInfo.variant} className={styles.stateBadge}>
+            {stateInfo.label}
+          </Badge>
         </div>
 
-        <div className={`${styles.detailsGrid} ${styles[viewMode]}`}>
-          {statsItems.map((item) => renderStatItem(item))}
+        <div className={styles.statusRight}>
+          {isApproved ? (
+            <>
+              <div className={styles.rewardBox}>
+                <FaTrophy className={styles.trophyIcon} />
+                <div className={styles.rewardContent}>
+                  <span className={styles.rewardLabel}>
+                    Recompensa obtenida
+                  </span>
+                  <div className={styles.rewardValueWrapper}>
+                    <FaCoins className={styles.coinIcon} />
+                    <span className={styles.rewardNumber}>
+                      {animatedReward}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              {shouldShowScore(gameType) && renderScoreGauge()}
+            </>
+          ) : (
+            <>
+              {renderRightMetric(
+                FaClipboardCheck,
+                "Intentos utilizados",
+                `${results.attempts} de ${activity.attempts}`
+              )}
+              {renderRightMetric(
+                FaClipboardCheck,
+                "Intentos restantes",
+                remainingAttempts > 0 ? remainingAttempts : "Sin intentos"
+              )}
+              {shouldShowScore(gameType) && renderScoreGauge()}
+            </>
+          )}
         </div>
-      </Card>
+      </motion.div>
+
+      {secondaryStats.length > 0 && (
+        <Card className={styles.secondaryStatsCard}>
+          <h3 className={styles.sectionTitle}>{getDetailsTitle()}</h3>
+          <div className={styles.secondaryStatsGrid}>
+            {secondaryStats.map((item, index) =>
+              renderSecondaryStat(item, index)
+            )}
+          </div>
+        </Card>
+      )}
     </motion.div>
   );
 };

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
@@ -3,12 +3,14 @@ import {
   FaColumns,
   FaList,
   FaTrophy,
+  FaStar,
   FaCheckCircle,
+  FaClipboardCheck,
   FaTimesCircle,
   FaQuestionCircle,
   FaClock,
 } from "react-icons/fa";
-import { FcStatistics, FcComments } from "react-icons/fc";
+import { FcStatistics } from "react-icons/fc";
 import type { IconType } from "react-icons";
 import type {
   ActivityResultsResponseInterface,
@@ -52,7 +54,7 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
     {
       id: "state",
       icon: FcStatistics,
-      label: "Resultado",
+      label: "Estado",
       value: (
         <Badge variant={stateInfo.variant} className={styles.stateBadge}>
           {stateInfo.label}
@@ -71,9 +73,9 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
   if (shouldShowScore(gameType)) {
     statsItems.push({
       id: "score",
-      icon: FcStatistics,
+      icon: FaStar,
       label: "Puntuación",
-      value: `${results.score} puntos`,
+      value: `${results.score}/100 puntos`,
       className: styles.scoreValue,
     });
   }
@@ -88,9 +90,10 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
     },
     {
       id: "attempts",
-      icon: FcStatistics,
+      icon: FaClipboardCheck,
       label: "Intentos utilizados",
       value: `${results.attempts} de ${activity.attempts}`,
+      className: styles.attemptsValue,
     }
   );
 
@@ -162,18 +165,6 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
 
         <div className={`${styles.detailsGrid} ${styles[viewMode]}`}>
           {statsItems.map((item) => renderStatItem(item))}
-
-          <div className={styles.detailItem}>
-            <div className={styles.detailContent}>
-              <FcComments className={styles.detailIcon} />
-              <div>
-                <span className={styles.label}>Comentarios del docente</span>
-                <span className={`${styles.value} ${styles.teacherComments}`}>
-                  El docente no ha realizado comentarios aún
-                </span>
-              </div>
-            </div>
-          </div>
         </div>
       </Card>
     </motion.div>

--- a/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
+++ b/src/student/components/studentActivityResults/activityResultsStats/ActivityResultsStats.tsx
@@ -259,7 +259,9 @@ const ActivityResultsStats: React.FC<ActivityResultsStatsProps> = ({
 
       {secondaryStats.length > 0 && (
         <Card className={styles.secondaryStatsCard}>
-          <h3 className={styles.sectionTitle}>{getDetailsTitle()}</h3>
+          <div className={styles.sectionHeader}>
+            <h3 className={styles.sectionTitle}>{getDetailsTitle()}</h3>
+          </div>
           <div className={styles.secondaryStatsGrid}>
             {secondaryStats.map((item, index) =>
               renderSecondaryStat(item, index)

--- a/src/student/components/studentCompletedActivityViewComponents/ActionButtons/ActionButtons.tsx
+++ b/src/student/components/studentCompletedActivityViewComponents/ActionButtons/ActionButtons.tsx
@@ -1,8 +1,9 @@
-import { motion, type Variants } from "framer-motion";
-import styles from "./ActionButtons.module.css";
 import { useNavigate } from "react-router-dom";
-import { useGameManager } from "@/shared";
+import { motion, type Variants } from "framer-motion";
 import type { CurrentActivityInterface } from "../../../types/Activity.type";
+import { useGameManager } from "@/shared";
+import styles from "./ActionButtons.module.css";
+
 interface ActionButtonsProps {
   passed: boolean;
   activity: CurrentActivityInterface;

--- a/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentContextAPI.type.ts
+++ b/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentContextAPI.type.ts
@@ -4,6 +4,7 @@ import type {
   ActivityApprovedResponseInterface,
   CurrentActivityInterface,
   ActivityStatsResponse,
+  ActivityResultsResponseInterface,
 } from "../../../types/Activity.type";
 import type {
   ActivityCompletedInterface,
@@ -20,6 +21,7 @@ export interface ActivityStudentContextType {
   currentActivity: CurrentActivityInterface | null;
   activityCompleted: ActivityCompletedResponseInterface | null;
   activityStudentStats: ActivityStatsResponse | null;
+  activityResults: ActivityResultsResponseInterface | null;
 
   // Funciones Principales
   getActivityNotApproved: () => Promise<void>;
@@ -28,6 +30,7 @@ export interface ActivityStudentContextType {
   getPaginatedActivitiesNotApproved: (params: GetPaginated) => Promise<void>;
   getPaginatedActivitiesApproved: (params: GetPaginated) => Promise<void>;
   getActivityStudentStats: () => Promise<void>;
+  getActivityResults: (activityId: number) => Promise<void>;
   registerActivityStarted: (id: number) => Promise<void>;
   registerActivityCompleted: (
     payload: ActivityCompletedInterface

--- a/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentContextAPI.type.ts
+++ b/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentContextAPI.type.ts
@@ -11,6 +11,11 @@ import type {
   ActivityCompletedResponseInterface,
 } from "../../../types/ActivityCompleted.type";
 
+export interface CurrentActivityAttemptInfo {
+  remainingAttempts: number;
+  completedAt?: string;
+}
+
 export interface ActivityStudentContextType {
   // Estados principales
   loading: boolean;
@@ -22,6 +27,7 @@ export interface ActivityStudentContextType {
   activityCompleted: ActivityCompletedResponseInterface | null;
   activityStudentStats: ActivityStatsResponse | null;
   activityResults: ActivityResultsResponseInterface | null;
+  currentActivityAttemptInfo: CurrentActivityAttemptInfo | null;
 
   // Funciones Principales
   getActivityNotApproved: () => Promise<void>;
@@ -39,4 +45,7 @@ export interface ActivityStudentContextType {
 
   // Funciones Auxiliares
   refreshActivityDataAfterCompletion: () => Promise<void>;
+  setCurrentActivityAttemptInfo: (
+    info: CurrentActivityAttemptInfo | null
+  ) => void;
 }

--- a/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentProviderAPI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentProviderAPI.tsx
@@ -6,6 +6,7 @@ import type {
   ActivityApprovedResponseInterface,
   CurrentActivityInterface,
   ActivityStatsResponse,
+  ActivityResultsResponseInterface,
 } from "../../../types/Activity.type";
 import type {
   ActivityCompletedInterface,
@@ -49,6 +50,8 @@ export const ActivityStudentProvider = ({
     useState<ActivityCompletedResponseInterface | null>(null);
   const [activityStudentStats, setActivityStudentStats] =
     useState<ActivityStatsResponse | null>(null);
+  const [activityResults, setActivityResults] =
+    useState<ActivityResultsResponseInterface | null>(null);
 
   // Funciones Principales
   const getPaginatedActivitiesNotApproved = useCallback(
@@ -146,6 +149,26 @@ export const ActivityStudentProvider = ({
     }
   }, []);
 
+  const getActivityResults = useCallback(
+    async (activityId: number): Promise<void> => {
+      setLoading(true);
+      try {
+        const response = await ActivityStudentService.getActivityResultsApi(
+          activityId
+        );
+        setActivityResults(response.data);
+      } catch (error) {
+        handleApiError(
+          error,
+          "Error al obtener los resultados de la actividad"
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
   const registerActivityStarted = useCallback(
     async (id: number): Promise<void> => {
       setLoading(true);
@@ -213,6 +236,7 @@ export const ActivityStudentProvider = ({
     currentActivity,
     activityCompleted,
     activityStudentStats,
+    activityResults,
 
     // Funciones Principales
     getActivityNotApproved,
@@ -221,6 +245,7 @@ export const ActivityStudentProvider = ({
     getPaginatedActivitiesApproved,
     getPaginatedActivitiesNotApproved,
     getActivityStudentStats,
+    getActivityResults,
     registerActivityStarted,
     registerActivityCompleted,
     registerActivityNoLudicaCompleted,

--- a/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentProviderAPI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentProviderAPI.tsx
@@ -5,6 +5,7 @@ import type {
   ActivityNotApprovedResponseInterface,
   ActivityApprovedResponseInterface,
   CurrentActivityInterface,
+  CurrentActivityAttemptInfo,
   ActivityStatsResponse,
   ActivityResultsResponseInterface,
 } from "../../../types/Activity.type";
@@ -20,7 +21,6 @@ import {
   useHandleApiError,
   usePaginationParams,
 } from "@/shared";
-
 import { useCurrentStudent } from "../../../hooks/useCurrentStudent";
 
 export const ActivityStudentProvider = ({
@@ -52,6 +52,8 @@ export const ActivityStudentProvider = ({
     useState<ActivityStatsResponse | null>(null);
   const [activityResults, setActivityResults] =
     useState<ActivityResultsResponseInterface | null>(null);
+  const [currentActivityAttemptInfo, setCurrentActivityAttemptInfo] =
+    useState<CurrentActivityAttemptInfo | null>(null);
 
   // Funciones Principales
   const getPaginatedActivitiesNotApproved = useCallback(
@@ -237,6 +239,7 @@ export const ActivityStudentProvider = ({
     activityCompleted,
     activityStudentStats,
     activityResults,
+    currentActivityAttemptInfo,
 
     // Funciones Principales
     getActivityNotApproved,
@@ -252,6 +255,7 @@ export const ActivityStudentProvider = ({
 
     // Funciones Auxiliares
     refreshActivityDataAfterCompletion,
+    setCurrentActivityAttemptInfo,
   };
 
   return (

--- a/src/student/hooks/activities/activityList/useActivityData.ts
+++ b/src/student/hooks/activities/activityList/useActivityData.ts
@@ -48,6 +48,7 @@ export const useActivityData = () => {
     if (activeFilter === "APPROVED") {
       await getPaginatedActivitiesApproved({
         ...paginationParams,
+        order_type: "desc",
         filters:
           selectedSubject && selectedSubject.id !== "ALL" ? ["subjectId"] : [],
         filtersValues:
@@ -83,6 +84,7 @@ export const useActivityData = () => {
 
     await getPaginatedActivitiesNotApproved({
       ...paginationParams,
+      order_type: "desc",
       filters,
       filtersValues,
     });

--- a/src/student/hooks/activities/activityResults/useActivityResults.ts
+++ b/src/student/hooks/activities/activityResults/useActivityResults.ts
@@ -1,10 +1,7 @@
-import { useState, useEffect } from "react";
-import { ActivityStudentService } from "../../../services/activity/ActivityService";
-import type {
-  ActivityResultsResponseInterface,
-  CurrentActivityInterface,
-} from "../../../types/Activity.type";
-import { getGameTypeFromActivityName, createGameConfig } from "@/shared";
+import { useEffect } from "react";
+import type { ActivityResultsResponseInterface } from "@/student/types/Activity.type";
+import type { CurrentActivityInterface } from "@/student/types/Activity.type";
+import { useActivityStudent } from "../../useActivityStudentAPI";
 
 interface UseActivityResultsReturn {
   results: ActivityResultsResponseInterface | null;
@@ -16,56 +13,29 @@ interface UseActivityResultsReturn {
 export const useActivityResults = (
   activityId: number
 ): UseActivityResultsReturn => {
-  const [results, setResults] =
-    useState<ActivityResultsResponseInterface | null>(null);
-  const [activity, setActivity] = useState<CurrentActivityInterface | null>(
-    null
-  );
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    currentActivity,
+    activityResults,
+    loading: contextLoading,
+    getActivityById,
+    getActivityResults,
+  } = useActivityStudent();
 
   useEffect(() => {
-    const fetchResults = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        const [activityResponse, resultsResponse] = await Promise.all([
-          ActivityStudentService.getActivityByIdApi(activityId),
-          ActivityStudentService.getActivityResultsApi(activityId),
-        ]);
-
-        const activityData = activityResponse.data;
-        const gameType = getGameTypeFromActivityName(activityData.name);
-
-        if (!gameType) {
-          throw new Error(
-            `Tipo de juego desconocido para: "${activityData.name}"`
-          );
-        }
-
-        const transformedActivity: CurrentActivityInterface = {
-          ...activityData,
-          gameConfig: createGameConfig(gameType, activityData),
-        };
-
-        setActivity(transformedActivity);
-        setResults(resultsResponse.data);
-      } catch (err: any) {
-        setError(
-          err?.response?.data?.message ||
-            "Error al cargar los resultados de la actividad"
-        );
-        console.error("Error fetching activity results:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     if (activityId) {
-      fetchResults();
+      Promise.all([
+        getActivityById(activityId),
+        getActivityResults(activityId),
+      ]).catch(() => {
+        // Los errores ya son manejados por handleApiError en el provider
+      });
     }
-  }, [activityId]);
+  }, [activityId, getActivityById, getActivityResults]);
 
-  return { results, activity, loading, error };
+  return {
+    results: activityResults,
+    activity: currentActivity,
+    loading: contextLoading,
+    error: null,
+  };
 };

--- a/src/student/hooks/activities/activityResults/useActivityResults.ts
+++ b/src/student/hooks/activities/activityResults/useActivityResults.ts
@@ -1,9 +1,14 @@
 import { useState, useEffect } from "react";
 import { ActivityStudentService } from "../../../services/activity/ActivityService";
-import type { ActivityResultsResponseInterface } from "../../../types/Activity.type";
+import type {
+  ActivityResultsResponseInterface,
+  CurrentActivityInterface,
+} from "../../../types/Activity.type";
+import { getGameTypeFromActivityName, createGameConfig } from "@/shared";
 
 interface UseActivityResultsReturn {
   results: ActivityResultsResponseInterface | null;
+  activity: CurrentActivityInterface | null;
   loading: boolean;
   error: string | null;
 }
@@ -13,6 +18,9 @@ export const useActivityResults = (
 ): UseActivityResultsReturn => {
   const [results, setResults] =
     useState<ActivityResultsResponseInterface | null>(null);
+  const [activity, setActivity] = useState<CurrentActivityInterface | null>(
+    null
+  );
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,8 +30,26 @@ export const useActivityResults = (
         setLoading(true);
         setError(null);
 
-        const resultsResponse =
-          await ActivityStudentService.getActivityResultsApi(activityId);
+        const [activityResponse, resultsResponse] = await Promise.all([
+          ActivityStudentService.getActivityByIdApi(activityId),
+          ActivityStudentService.getActivityResultsApi(activityId),
+        ]);
+
+        const activityData = activityResponse.data;
+        const gameType = getGameTypeFromActivityName(activityData.name);
+
+        if (!gameType) {
+          throw new Error(
+            `Tipo de juego desconocido para: "${activityData.name}"`
+          );
+        }
+
+        const transformedActivity: CurrentActivityInterface = {
+          ...activityData,
+          gameConfig: createGameConfig(gameType, activityData),
+        };
+
+        setActivity(transformedActivity);
         setResults(resultsResponse.data);
       } catch (err: any) {
         setError(
@@ -41,5 +67,5 @@ export const useActivityResults = (
     }
   }, [activityId]);
 
-  return { results, loading, error };
+  return { results, activity, loading, error };
 };

--- a/src/student/hooks/activities/activityResults/useActivityResults.ts
+++ b/src/student/hooks/activities/activityResults/useActivityResults.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from "react";
+import { ActivityStudentService } from "../../../services/activity/ActivityService";
+import type { ActivityResultsResponseInterface } from "../../../types/Activity.type";
+
+interface UseActivityResultsReturn {
+  results: ActivityResultsResponseInterface | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export const useActivityResults = (
+  activityId: number
+): UseActivityResultsReturn => {
+  const [results, setResults] =
+    useState<ActivityResultsResponseInterface | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const resultsResponse =
+          await ActivityStudentService.getActivityResultsApi(activityId);
+        setResults(resultsResponse.data);
+      } catch (err: any) {
+        setError(
+          err?.response?.data?.message ||
+            "Error al cargar los resultados de la actividad"
+        );
+        console.error("Error fetching activity results:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (activityId) {
+      fetchResults();
+    }
+  }, [activityId]);
+
+  return { results, loading, error };
+};

--- a/src/student/hooks/activities/useActivityActions.ts
+++ b/src/student/hooks/activities/useActivityActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import type { GameHook } from "@/shared";
 import { useActivityStudent } from "../../../student/hooks/useActivityStudentAPI";
 import { useConfirmation, usePaginationParams } from "@/shared";
 import { useActivityRules } from "./useActivityRules";
@@ -59,7 +60,11 @@ export const useActivityActions = () => {
   );
 
   const finishActivity = useCallback(
-    async (isApproved: boolean, onAfterFinish?: () => void) => {
+    async (
+      isApproved: boolean,
+      gameManager?: GameHook | null,
+      onAfterFinish?: () => void
+    ) => {
       if (!currentActivity) return;
 
       showConfirmation({
@@ -75,6 +80,10 @@ export const useActivityActions = () => {
             await registerActivityCompleted({
               activityId: currentActivity.id,
               state: isApproved ? "APPROVED" : "DISAPPROVED",
+              score: gameManager?.score ?? null,
+              correctAnswers: gameManager?.correctAnswers ?? null,
+              incorrectAnswers: gameManager?.incorrectAnswers ?? null,
+              unanswered: gameManager?.unanswered ?? null,
             });
           }
 
@@ -104,7 +113,11 @@ export const useActivityActions = () => {
   );
 
   const forceFinishActivity = useCallback(
-    async (isApproved: boolean, onAfterFinish?: () => void) => {
+    async (
+      isApproved: boolean,
+      gameManager?: GameHook | null,
+      onAfterFinish?: () => void
+    ) => {
       if (!currentActivity) return;
 
       isFinishingActivity.current = true;
@@ -112,6 +125,10 @@ export const useActivityActions = () => {
       await registerActivityCompleted({
         activityId: currentActivity.id,
         state: isApproved ? "APPROVED" : "DISAPPROVED",
+        score: gameManager?.score ?? null,
+        correctAnswers: gameManager?.correctAnswers ?? null,
+        incorrectAnswers: gameManager?.incorrectAnswers ?? null,
+        unanswered: gameManager?.unanswered ?? null,
       });
 
       await refreshActivityDataAfterCompletion();

--- a/src/student/hooks/activities/useActivityActions.ts
+++ b/src/student/hooks/activities/useActivityActions.ts
@@ -15,6 +15,7 @@ export const useActivityActions = () => {
     refreshActivityDataAfterCompletion,
     getPaginatedActivitiesApproved,
     getPaginatedActivitiesNotApproved,
+    setCurrentActivityAttemptInfo,
   } = useActivityStudent();
 
   const { clearPersistedActivity } = useCurrentActivityPersistence();
@@ -36,10 +37,18 @@ export const useActivityActions = () => {
   );
 
   const viewActivityResults = useCallback(
-    (activityId: number | string) => {
+    (
+      activityId: number | string,
+      remainingAttempts: number,
+      completedAt?: string
+    ) => {
+      setCurrentActivityAttemptInfo({
+        remainingAttempts,
+        completedAt,
+      });
       navigate(`/dashboard/student/actividades/${activityId}/results`);
     },
-    [navigate]
+    [navigate, setCurrentActivityAttemptInfo]
   );
 
   const startActivity = useCallback(

--- a/src/student/hooks/activities/useActivityActions.ts
+++ b/src/student/hooks/activities/useActivityActions.ts
@@ -35,6 +35,13 @@ export const useActivityActions = () => {
     [getActivityById, navigate]
   );
 
+  const viewActivityResults = useCallback(
+    (activityId: number | string) => {
+      navigate(`/dashboard/student/actividades/${activityId}/results`);
+    },
+    [navigate]
+  );
+
   const startActivity = useCallback(
     (activityId: number | string) => {
       showConfirmation({
@@ -174,6 +181,7 @@ export const useActivityActions = () => {
 
   return {
     viewActivity,
+    viewActivityResults,
     startActivity,
     finishActivity,
     forceFinishActivity,

--- a/src/student/services/activity/ActivityService.ts
+++ b/src/student/services/activity/ActivityService.ts
@@ -78,6 +78,11 @@ const getActivityStudentStatsApi =
     return response.data;
   };
 
+const getActivityResultsApi = async (activityId: number) => {
+  const response = await api.get(urls.ActivityResults(activityId));
+  return response.data;
+};
+
 const registerActivityStartedApi = async (
   id: number
 ): Promise<{ data: ActivityCompletedResponseInterface }> => {
@@ -107,6 +112,7 @@ export const ActivityStudentService = {
   getPaginatedActivityApprovedApi,
   getActivityByIdApi,
   getActivityStudentStatsApi,
+  getActivityResultsApi,
   registerActivityStartedApi,
   registerActivityCompletedApi,
   registerActivityNoLudicaCompleteApi,

--- a/src/student/services/urls.ts
+++ b/src/student/services/urls.ts
@@ -9,6 +9,8 @@ export const urls = {
   ActivityCompleted: "/activity/completed",
   ActivityNoLudicaComplete: "/activity/completed/no-ludica",
   ActivityStudentStats: "/activity/student/count",
+  ActivityResults: (activityId: number) =>
+    `/activity/completed/results/${activityId}`,
 
   // Student
   StudentByToken: "/student",

--- a/src/student/types/Activity.type.ts
+++ b/src/student/types/Activity.type.ts
@@ -76,10 +76,12 @@ export interface ActivityUI {
   rewardLabel?: string;
   reward?: string;
   remainingAttempts: number;
+  attempts: number;
   attemptsLabel: string;
   noAttempts: boolean;
   dueDateLabel?: string;
   extraInfo?: string;
+  completedAt?: string;
 }
 
 export type GameConfig =
@@ -105,6 +107,11 @@ export interface CurrentActivityInterface {
   initialBalance: number;
   typeReward: string;
   gameConfig: GameConfig;
+}
+
+export interface CurrentActivityAttemptInfo {
+  remainingAttempts: number;
+  completedAt?: string;
 }
 
 export interface ActivityResultsResponseInterface {

--- a/src/student/types/Activity.type.ts
+++ b/src/student/types/Activity.type.ts
@@ -106,3 +106,16 @@ export interface CurrentActivityInterface {
   typeReward: string;
   gameConfig: GameConfig;
 }
+
+export interface ActivityResultsResponseInterface {
+  id: number;
+  activityId: number;
+  state: "APPROVED" | "DISAPPROVED" | "PENDING";
+  attempts: number;
+  reward: number;
+  completedTimeInSeconds: number;
+  score: number;
+  correctAnswers: number;
+  incorrectAnswers: number;
+  unanswered: number;
+}

--- a/src/student/types/ActivityCompleted.type.ts
+++ b/src/student/types/ActivityCompleted.type.ts
@@ -3,6 +3,10 @@ export type ActivityCompletedState = "APPROVED" | "DISAPPROVED" | "PENDING";
 export interface ActivityCompletedInterface {
   activityId: number;
   state: ActivityCompletedState;
+  score: number | null;
+  correctAnswers: number | null;
+  incorrectAnswers: number | null;
+  unanswered: number | null;
 }
 
 export interface ActivityCompletedResponseInterface {

--- a/src/student/utils/activityResults.utils.ts
+++ b/src/student/utils/activityResults.utils.ts
@@ -1,0 +1,78 @@
+import { ActivityResultsStrategyFactory } from "@/shared";
+import type { GameType } from "../../shared/types/Games.type";
+
+/**
+ * Formatea el estado de una actividad completada
+ */
+export const formatResultState = (
+  state: "APPROVED" | "DISAPPROVED" | "PENDING"
+): { label: string; variant: "success" | "danger" | "warning" } => {
+  switch (state) {
+    case "APPROVED":
+      return { label: "Aprobada", variant: "success" };
+    case "DISAPPROVED":
+      return { label: "Desaprobada", variant: "danger" };
+    case "PENDING":
+      return { label: "Pendiente", variant: "warning" };
+    default:
+      return { label: "Desconocido", variant: "warning" };
+  }
+};
+
+/**
+ * Formatea el tiempo de realización en formato legible
+ */
+export const formatCompletedTime = (seconds: number): string => {
+  if (seconds < 60) {
+    return `${seconds} segundo${seconds !== 1 ? "s" : ""}`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (minutes < 60) {
+    if (remainingSeconds === 0) {
+      return `${minutes} minuto${minutes !== 1 ? "s" : ""}`;
+    }
+    return `${minutes} minuto${
+      minutes !== 1 ? "s" : ""
+    } y ${remainingSeconds} segundo${remainingSeconds !== 1 ? "s" : ""}`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (remainingMinutes === 0) {
+    return `${hours} hora${hours !== 1 ? "s" : ""}`;
+  }
+  return `${hours} hora${hours !== 1 ? "s" : ""} y ${remainingMinutes} minuto${
+    remainingMinutes !== 1 ? "s" : ""
+  }`;
+};
+
+/**
+ * Obtiene los labels dinámicos de estadísticas según el tipo de juego usando Strategy Pattern
+ */
+export const getStatsLabels = (gameType: GameType) => {
+  const strategy = ActivityResultsStrategyFactory.createStrategy(gameType);
+  return strategy.getStatsLabels();
+};
+
+/**
+ * Determina si se debe mostrar una estadística específica
+ */
+export const shouldShowStat = (
+  gameType: GameType,
+  statType: "correctAnswers" | "incorrectAnswers" | "unanswered"
+): boolean => {
+  const labels = getStatsLabels(gameType);
+  return labels[statType] !== null;
+};
+
+/**
+ * Determina si se debe mostrar el score según el tipo de juego
+ */
+export const shouldShowScore = (gameType: GameType): boolean => {
+  const strategy = ActivityResultsStrategyFactory.createStrategy(gameType);
+  return strategy.shouldShowScore();
+};

--- a/src/student/views/studentActivityResultsView/StudentActivityResultsView.module.css
+++ b/src/student/views/studentActivityResultsView/StudentActivityResultsView.module.css
@@ -1,0 +1,81 @@
+.activityView {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.mainContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  text-align: center;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 2rem;
+}
+
+.errorContainer h2 {
+  color: var(--color-text-error);
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.errorContainer p {
+  color: rgba(255, 255, 255, 0.8);
+  margin: 0;
+}
+
+.backButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-third));
+  color: white;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.backButton:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(130, 1, 141, 0.3);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .activityView {
+    padding: 0 0.5rem;
+    gap: 1.5rem;
+  }
+
+  .mainContent {
+    gap: 1rem;
+  }
+}

--- a/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
+++ b/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
@@ -6,6 +6,7 @@ import StudentActivityHeader from "../../components/common/StudentActivityHeader
 import StudentActivityFooter from "../../components/common/StudentActivityFooter/StudentActivityFooter";
 import ActivityResultsDetails from "../../components/studentActivityResults/activityResultsDetails/ActivityResultsDetails";
 import ActivityResultsStats from "../../components/studentActivityResults/activityResultsStats/ActivityResultsStats";
+import ActivityResultsFeedback from "../../components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback";
 import { useActivityResults } from "../../hooks/activities/activityResults/useActivityResults";
 import { useActivityNavigation } from "../../hooks/activities/useActivityNavigation";
 import styles from "./StudentActivityResultsView.module.css";
@@ -63,6 +64,10 @@ const StudentActivityResultsView: React.FC = () => {
       <div className={styles.mainContent}>
         <ActivityResultsDetails activity={activity} />
         <ActivityResultsStats results={results} activity={activity} />
+        <ActivityResultsFeedback
+          teacherComment={"El docente no ha realizado comentarios aún"}
+        />
+        {/* <ActivityResultsFeedback teacherComment={results.teacherComment} /> */}
       </div>
 
       <StudentActivityFooter

--- a/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
+++ b/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
@@ -1,0 +1,77 @@
+import { useParams } from "react-router-dom";
+import { motion } from "framer-motion";
+import { FaTrophy } from "react-icons/fa";
+import { LoadingSpinnerComponent } from "@/shared";
+import StudentActivityHeader from "../../components/common/StudentActivityHeader/StudentActivityHeader";
+import StudentActivityFooter from "../../components/common/StudentActivityFooter/StudentActivityFooter";
+import ActivityResultsDetails from "../../components/studentActivityResults/activityResultsDetails/ActivityResultsDetails";
+import ActivityResultsStats from "../../components/studentActivityResults/activityResultsStats/ActivityResultsStats";
+import { useActivityResults } from "../../hooks/activities/activityResults/useActivityResults";
+import { useActivityNavigation } from "../../hooks/activities/useActivityNavigation";
+import styles from "./StudentActivityResultsView.module.css";
+
+const StudentActivityResultsView: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { results, activity, loading, error } = useActivityResults(Number(id));
+  const { goBackToList } = useActivityNavigation();
+
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+      },
+    },
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.loadingContainer}>
+        <LoadingSpinnerComponent />
+      </div>
+    );
+  }
+
+  if (error || !results || !activity) {
+    return (
+      <div className={styles.errorContainer}>
+        <h2>Error al cargar resultados</h2>
+        <p>
+          {error || "No se pudieron cargar los resultados de la actividad."}
+        </p>
+        <button onClick={goBackToList} className={styles.backButton}>
+          Volver a actividades
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+      className={styles.activityView}
+    >
+      <StudentActivityHeader
+        icon={<FaTrophy />}
+        title={activity.name}
+        subtitle="Resultados de la actividad"
+      />
+
+      <div className={styles.mainContent}>
+        <ActivityResultsDetails activity={activity} />
+        <ActivityResultsStats results={results} activity={activity} />
+      </div>
+
+      <StudentActivityFooter
+        loading={false}
+        onBack={goBackToList}
+        showBackToList={true}
+      />
+    </motion.div>
+  );
+};
+
+export default StudentActivityResultsView;

--- a/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
+++ b/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
@@ -9,12 +9,14 @@ import ActivityResultsStats from "../../components/studentActivityResults/activi
 import ActivityResultsFeedback from "../../components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback";
 import { useActivityResults } from "../../hooks/activities/activityResults/useActivityResults";
 import { useActivityNavigation } from "../../hooks/activities/useActivityNavigation";
+import { useActivityStudent } from "../../hooks/useActivityStudentAPI";
 import styles from "./StudentActivityResultsView.module.css";
 
 const StudentActivityResultsView: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { results, activity, loading, error } = useActivityResults(Number(id));
-  const { goBackToList } = useActivityNavigation();
+  const { goBackToList, goBackToActivityView } = useActivityNavigation();
+  const { currentActivityAttemptInfo } = useActivityStudent();
 
   const containerVariants = {
     hidden: { opacity: 0 },
@@ -48,6 +50,14 @@ const StudentActivityResultsView: React.FC = () => {
     );
   }
 
+  const remainingAttempts = currentActivityAttemptInfo?.remainingAttempts || 0;
+  const hasRemainingAttempts = remainingAttempts > 0;
+  const isApproved = results.state === "APPROVED";
+
+  const handleViewDetails = () => {
+    goBackToActivityView();
+  };
+
   return (
     <motion.div
       variants={containerVariants}
@@ -62,18 +72,22 @@ const StudentActivityResultsView: React.FC = () => {
       />
 
       <div className={styles.mainContent}>
-        <ActivityResultsDetails activity={activity} />
         <ActivityResultsStats results={results} activity={activity} />
+        <ActivityResultsDetails activity={activity} />
         <ActivityResultsFeedback
           teacherComment={"El docente no ha realizado comentarios aún"}
         />
-        {/* <ActivityResultsFeedback teacherComment={results.teacherComment} /> */}
       </div>
 
       <StudentActivityFooter
         loading={false}
         onBack={goBackToList}
-        showBackToList={true}
+        showBackToList={false}
+        backButtonText="Volver a Actividades"
+        onNext={
+          !isApproved && hasRemainingAttempts ? handleViewDetails : undefined
+        }
+        nextButtonText="Ver Detalles"
       />
     </motion.div>
   );

--- a/src/student/views/studentPlayActivityView/StudentPlayActivityView.tsx
+++ b/src/student/views/studentPlayActivityView/StudentPlayActivityView.tsx
@@ -81,14 +81,18 @@ const StudentPlayActivityView: React.FC<StudentPlayActivityViewProps> = ({
     if (!currentActivity) return;
 
     if (isNoLudica) {
-      await finishActivity(!!gameManager?.isGameWon, handleFinishNoLudica);
+      await finishActivity(
+        !!gameManager?.isGameWon,
+        gameManager,
+        handleFinishNoLudica
+      );
     } else {
-      await finishActivity(!!gameManager?.isGameWon);
+      await finishActivity(!!gameManager?.isGameWon, gameManager);
     }
   };
 
   const handleTimeUp = () => {
-    forceFinishActivity(false);
+    forceFinishActivity(false, gameManager);
   };
 
   if (loading) {


### PR DESCRIPTION
# Descripción
Se creó la vista de resultados detallados de actividades para estudiantes

# Explicación
## Resumen
Se implementó la vista que permite a los estudiantes visualizar el detalle completo de los resultados de una actividad realizada, cumpliendo con los criterios de aceptación de la historia de usuario “Visualizar resultados de actividades”.

La vista muestra información general de la actividad junto con métricas específicas y contextualizadas según el tipo de actividad.

## Normalización de resultados de actividades
Se normalizaron los atributos de una actividad completada incorporando al GameHook los siguientes campos:
- score;
- correctAnswers;
- incorrectAnswers;
- unanswered.

## Strategy Pattern para resultados por tipo de actividad
Se implementó el patrón Strategy para que se muestren labels semánticamente correctos según el tipo de actividad. Por ejemplo:

```ts
// AhorcadoResultsStrategy.ts
export class AhorcadoResultsStrategy implements ActivityResultsStrategy {
  getStatsLabels(): StatsLabels {
    return {
      correctAnswers: "Letras correctas",
      incorrectAnswers: "Letras incorrectas",
      unanswered: null, // No mostrar
    };
  }

  shouldShowScore(): boolean {
    return true;
  }
}
```

## Simple Factory para resolución de estrategias
Se creó una Simple Factory encargada de devolver la estrategia correcta según el gameType de la actividad.
```ts
// gameResultsFactory.ts
export class ActivityResultsStrategyFactory {
  static createStrategy(gameType: GameType): ActivityResultsStrategy {
    switch (gameType) {
      case "ahorcado":
        return new AhorcadoResultsStrategy();
      case "desafio de clasificacion":
        return new DesafioClasificacionResultsStrategy();
      case "completar oracion":
        return new CompletarOracionResultsStrategy();
      case "preguntados":
        return new PreguntadosResultsStrategy();
      case "no ludica":
        return new NoLudicaResultsStrategy();
      default:
        return new DefaultResultsStrategy();
    }
  }
}
```

## Otras features que complementan
**Constante de dificultades:** Se creó una constante centralizada para los niveles de dificultad de las actividades (no entiendo como no teníamos esto).
**Orden de actividades aprobadas y desaprobadas**: Se aplico el filtro order_type: "desc" para que filtro descendiente por id (de esta manera se muestran las últimas aprobadas y últimas desaprobadas y no tenemos que ir hasta el último).
**Label desaprobadas**: Despues de 500.000 años, finalemente tenemos el label de desaprobadas en las actividades. Si, no lo teníamos. Una actividad se cuenta desaprobada si no tiene intentos disponibles y no está aprobada (del back viene CREATED, APPROVED o EXPIRED, terrible los malabares que hice).

## Vista de resultados (WIP)
Accede haciendo click en "Ver Resultados"
<img width="1353" height="167" alt="image" src="https://github.com/user-attachments/assets/8d69462d-059f-4c07-be32-07abd1de43e2" />

WIP: Resultados (sin header ni footer en la foto así entraba todo en una)
<img width="1396" height="886" alt="image" src="https://github.com/user-attachments/assets/462935eb-6cbf-4f24-8d7c-fb110ca9c956" />

## Vista de resultados (Version "final")
Un estudiante puede acceder a la vista de resultados cuando:
- Una actividad se encuentra disponible pero realizó un intento (ver último intento)
<img width="1351" height="150" alt="image" src="https://github.com/user-attachments/assets/6c5c5f79-a653-4d22-81bb-323c9bae3378" />

- Una actividad fue aprobada (ver resultados)
<img width="1357" height="164" alt="image" src="https://github.com/user-attachments/assets/19d7a497-ad55-4669-8530-929f5efae842" />

- Una actividad fue desaprobada (ver resultados)
<img width="1345" height="153" alt="image" src="https://github.com/user-attachments/assets/090912f3-6751-4ba9-9854-c266100726ed" />

Si le damos a **"Ver último intento"** de una actividad disponible que aún le quedan intentos se verá así (con un botón de ver detalles para ir a realizar la actividad por si lo desea):
<img width="920" height="890" alt="image" src="https://github.com/user-attachments/assets/2ef70590-cc8c-4139-a2d9-0d52c8e73770" />

Si le damos a **"Ver resultados"** de una actividad aprobada se verá así:
<img width="924" height="894" alt="image" src="https://github.com/user-attachments/assets/cbef251c-dd49-4d6f-89e3-251e367974ae" />

Si le damos a **"Ver resultados"** de una actividad desaprobada se verá así:
<img width="922" height="892" alt="image" src="https://github.com/user-attachments/assets/e5718857-3134-4ede-84d4-fbcc21341477" />

## Consideraciones
### Actividades viejas
Cuando le das a ver resultados en actividades viejas, tira un 500 y se rompe todo. Ni idea por qué pasa, pero con actividades nuevas eso NO pasa.

### Cosas pendientes
- [x] Mostrar correctamente el detalle para actividades desaprobadas.
- [x] Mejorar la agrupación visual de atributos y cards dentro de la vista de resultados.

# Issue Relacionada
Closes #273 