### PR TITLE
[#281] feat: Visualización de comentarios del docente

### DIFF
--- a/src/shared/strategies/renderers/activityResults/NoLudicaResultsStrategy.ts
+++ b/src/shared/strategies/renderers/activityResults/NoLudicaResultsStrategy.ts
@@ -13,6 +13,6 @@ export class NoLudicaResultsStrategy implements ActivityResultsStrategy {
   }
 
   shouldShowScore(): boolean {
-    return false;
+    return true;
   }
 }

--- a/src/student/components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback.tsx
+++ b/src/student/components/studentActivityResults/activityResultsFeedback/ActivityResultsFeedback.tsx
@@ -33,7 +33,7 @@ const ActivityResultsFeedback: React.FC<ActivityResultsFeedbackProps> = ({
                   }`}
                 >
                   {teacherComment ||
-                    "El docente no ha realizado comentarios aún"}
+                    "El docente corrigió la actividad pero no realizó comentarios"}
                 </span>
               </div>
             </div>

--- a/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentProviderAPI.tsx
+++ b/src/student/context/activityStudentContext/activityStudentContextAPI/ActivityStudentProviderAPI.tsx
@@ -62,7 +62,7 @@ export const ActivityStudentProvider = ({
       try {
         const response =
           await ActivityStudentService.getPaginatedActivityNotApprovedApi(
-            params
+            params,
           );
         setPaginatedActivitiesNotApproved(response.data);
       } catch (error) {
@@ -71,7 +71,7 @@ export const ActivityStudentProvider = ({
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   const getPaginatedActivitiesApproved = useCallback(
@@ -87,7 +87,7 @@ export const ActivityStudentProvider = ({
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   const getActivityNotApproved = useCallback(async (): Promise<void> => {
@@ -155,20 +155,19 @@ export const ActivityStudentProvider = ({
     async (activityId: number): Promise<void> => {
       setLoading(true);
       try {
-        const response = await ActivityStudentService.getActivityResultsApi(
-          activityId
-        );
+        const response =
+          await ActivityStudentService.getActivityResultsApi(activityId);
         setActivityResults(response.data);
       } catch (error) {
         handleApiError(
           error,
-          "Error al obtener los resultados de la actividad"
+          "Error al obtener los resultados de la actividad",
         );
       } finally {
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   const registerActivityStarted = useCallback(
@@ -182,7 +181,7 @@ export const ActivityStudentProvider = ({
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   const registerActivityCompleted = useCallback(
@@ -198,7 +197,7 @@ export const ActivityStudentProvider = ({
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   const registerActivityNoLudicaCompleted = useCallback(
@@ -207,7 +206,7 @@ export const ActivityStudentProvider = ({
       try {
         const response =
           await ActivityStudentService.registerActivityNoLudicaCompleteApi(
-            payload
+            payload,
           );
         setActivityCompleted(response.data);
       } catch (error) {
@@ -216,7 +215,7 @@ export const ActivityStudentProvider = ({
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   // Funciones Auxiliares

--- a/src/student/types/Activity.type.ts
+++ b/src/student/types/Activity.type.ts
@@ -125,4 +125,5 @@ export interface ActivityResultsResponseInterface {
   correctAnswers: number;
   incorrectAnswers: number;
   unanswered: number;
+  comment: string;
 }

--- a/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
+++ b/src/student/views/studentActivityResultsView/StudentActivityResultsView.tsx
@@ -74,9 +74,7 @@ const StudentActivityResultsView: React.FC = () => {
       <div className={styles.mainContent}>
         <ActivityResultsStats results={results} activity={activity} />
         <ActivityResultsDetails activity={activity} />
-        <ActivityResultsFeedback
-          teacherComment={"El docente no ha realizado comentarios aún"}
-        />
+        <ActivityResultsFeedback teacherComment={results.comment} />
       </div>
 
       <StudentActivityFooter


### PR DESCRIPTION
# Descripción
Se agregó la visualización de comentarios docentes

# Features
## Score
En primer lugar, se cambió la estrategia de resultados de las actividades no lúdicas para permitir visualizar el score (antes no mostraba el score)

```ts
// NoLudicaResultsStrategy.ts: src/shared/strategies/renderers/activityResults/NoLudicaResultsStrategy.ts

export class NoLudicaResultsStrategy implements ActivityResultsStrategy {
  getStatsLabels(): StatsLabels {
    return {
      correctAnswers: null, // No mostrar nada
      incorrectAnswers: null,
      unanswered: null,
    };
  }

  shouldShowScore(): boolean {
    return true; // era false
  }
}
```

Ahora se muestra tal y como en las otras estrategias que tienen shouldShowScore == true
<img width="1391" height="205" alt="image" src="https://github.com/user-attachments/assets/ad5c7f90-13fe-466e-85b2-24a7e2732ec2" />

## Visualización de comentarios
Se agregó el atributo "comment" a ActivityResultsResponseInterface, y se modificó el mensaje que se muestra si el docente no realiza comentarios.
<img width="1384" height="208" alt="image" src="https://github.com/user-attachments/assets/8ec072ea-3fd9-4bee-b670-249848836b7e" />

# Cosas para ver
Del backend, se está guardando el comentario como null aunque se agregue a la corrección de la actividad, por lo que aunque tecnicamente se va a mostrar el dia que se arregle, esperaría para ver bien la solución que dan los pibes.

# Issue relacionada
Closes #281 