### PR TITLE
[#297] feat: Agregar skin del perfil en los rankings

### DIFF
--- a/src/ranking/components/RankingPosition/RankingPosition.module.css
+++ b/src/ranking/components/RankingPosition/RankingPosition.module.css
@@ -9,7 +9,7 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
   transition: all 0.3s ease;
-  overflow: hidden;
+  /* overflow: hidden; */
 }
 
 .positionCard:hover {
@@ -74,18 +74,20 @@
   flex: 1;
 }
 
+
+
 .avatar {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 45px;
   height: 45px;
-  background: rgba(var(--color-secondary-rgb), 0.7);
+  background: rgba(255, 255, 255, 0.192);
   border-radius: 50%;
   color: white;
   font-size: 1.25rem;
   font-weight: 700;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.307);
 }
 
 .nameContainer {
@@ -130,29 +132,9 @@
   font-weight: 700;
 }
 
-.shine {
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: linear-gradient(
-    45deg,
-    transparent,
-    rgba(255, 255, 255, 0.1),
-    transparent
-  );
-  animation: shine 3s infinite;
-}
 
-@keyframes shine {
-  0% {
-    transform: translateX(-100%) translateY(-100%) rotate(45deg);
-  }
-  100% {
-    transform: translateX(100%) translateY(100%) rotate(45deg);
-  }
-}
+
+
 
 @media (max-width: 768px) {
   .positionCard {

--- a/src/ranking/components/RankingPosition/RankingPosition.tsx
+++ b/src/ranking/components/RankingPosition/RankingPosition.tsx
@@ -3,6 +3,8 @@ import { FaCoins, FaGamepad } from "react-icons/fa";
 import type { Position } from "../../types/ranking.type";
 import { useRankingPosition } from "../../hooks/useRankingPosition";
 import styles from "./RankingPosition.module.css";
+import Avatar from "@/student/components/common/Avatar/AvatarComponent";
+import type { AvatarComponentsPreview } from "@/student/types/CurrentStudent.type";
 
 interface RankingPositionProps {
   position: Position;
@@ -18,12 +20,16 @@ export const RankingPosition = ({
   isCurrentUser,
 }: RankingPositionProps) => {
   const { getMedalIcon } = useRankingPosition(position);
+  const avatar: AvatarComponentsPreview = {
+    selectedBody: position.selectedBody,
+    selectedHat: position.selectedHat,
+    selectedShirt: position.selectedShirt
+  }
 
   return (
     <motion.div
-      className={`${styles.positionCard} ${
-        isCurrentUser ? styles.currentUser : ""
-      } ${position.position <= 3 ? styles.topThree : ""}`}
+      className={`${styles.positionCard} ${isCurrentUser ? styles.currentUser : ""
+        } ${position.position <= 3 ? styles.topThree : ""}`}
       initial={{ opacity: 0, x: -20 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ delay: index * 0.05 }}
@@ -38,9 +44,20 @@ export const RankingPosition = ({
       </div>
 
       <div className={styles.userInfo}>
-        <div className={styles.avatar}>
-          {position.name.charAt(0).toUpperCase()}
-        </div>
+        <motion.div
+          initial={{ y: 0 }}
+          whileTap={{ y: -10, scale: 4, position: "absolute", top: "50%", left: "50%" }}
+          transition={{
+            type: "tween",
+          }}
+          className={styles.avatar}>
+          <Avatar
+            size="small"
+            previewState={avatar}
+          />
+        </motion.div>
+
+
         <div className={styles.nameContainer}>
           <p className={styles.name}>{position.name}</p>
           {isCurrentUser && <span className={styles.youBadge}>Tú</span>}

--- a/src/ranking/types/ranking.type.ts
+++ b/src/ranking/types/ranking.type.ts
@@ -1,11 +1,18 @@
+import type { BodyPart } from "@/admin";
+
 export interface Position {
   position: number;
   name: string;
   quantity: number;
+  selectedBody: BodyPart | null;
+  selectedShirt: BodyPart | null;
+  selectedHat: BodyPart | null;
 }
+
 export interface RankingResponseApi {
   currentUserPosition: Position;
   participants: Position[];
+
 }
 
 export type RankingType =


### PR DESCRIPTION
# Descripción 
Se agrego el avatar al listado del ranking.
<img width="1249" height="766" alt="image" src="https://github.com/user-attachments/assets/fcf1221f-2bad-4ef1-a17d-48ddba1a3f7b" />
 y si se le hace click se puede visualizar mas grande (sin el borde negro, quedo asi por el screen) para poder ver mejor el avatar del compañero.
 
<img width="1276" height="762" alt="image" src="https://github.com/user-attachments/assets/a48f8eea-c209-41e6-9d51-190dd5738177" />

 