### PR TITLE
[#318] fix: Entrega de PDFs por parte de estudiantes

### DIFF
--- a/src/shared/components/Games/NoLudica/NoLudicaGame.module.css
+++ b/src/shared/components/Games/NoLudica/NoLudicaGame.module.css
@@ -246,6 +246,26 @@
   text-align: center;
 }
 
+.removeFileButton {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  align-self: center;
+  padding: 0.375rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: #dc2626;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  transition: background 0.2s ease;
+}
+
+.removeFileButton:hover {
+  background: #fef2f2;
+}
+
 .urlInput {
   width: 100%;
   padding: 0.75rem;

--- a/src/shared/components/Games/NoLudica/NoLudicaGame.tsx
+++ b/src/shared/components/Games/NoLudica/NoLudicaGame.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { motion } from "framer-motion";
-import { FaEye } from "react-icons/fa";
+import { FaEye, FaUpload, FaTimes } from "react-icons/fa";
 import { useCreateNoLudica } from "../../../../activity/hooks/useCreateNoLudica";
 import { useNoLudicaGame } from "../../../hooks/games/useNoLudicaGame";
 import MDEditor from "@uiw/react-md-editor";
@@ -18,6 +18,9 @@ const NoLudicaGame = ({ mode }: NoLudicaGameProps) => {
     gameStarted,
     studentResponse,
     setStudentResponse,
+    selectedFile,
+    handleFileSelect,
+    handleRemoveFile,
   } = useNoLudicaGame();
 
   useEffect(() => {
@@ -71,6 +74,40 @@ const NoLudicaGame = ({ mode }: NoLudicaGameProps) => {
               {studentResponse.length}/1000 caracteres
             </div>
           </div>
+
+          {mode !== "preview" && (
+            <div className={styles.responseInput}>
+              <label className={styles.inputLabel}>Tu archivo:</label>
+              <div className={styles.fileUpload}>
+                <input
+                  type="file"
+                  id="file-upload"
+                  onChange={handleFileSelect}
+                  className={styles.fileInput}
+                  accept="application/pdf"
+                />
+                <label htmlFor="file-upload" className={styles.fileUploadLabel}>
+                  <FaUpload className={styles.uploadIcon} />
+                  <span>
+                    {selectedFile ? selectedFile.name : "Seleccionar archivo"}
+                  </span>
+                </label>
+                {selectedFile && (
+                  <button
+                    type="button"
+                    onClick={handleRemoveFile}
+                    className={styles.removeFileButton}
+                  >
+                    <FaTimes />
+                    <span>Quitar archivo</span>
+                  </button>
+                )}
+                <div className={styles.acceptedFormats}>
+                  Formato aceptado: PDF
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </motion.div>

--- a/src/shared/components/Games/NoLudica/NoLudicaGame.tsx
+++ b/src/shared/components/Games/NoLudica/NoLudicaGame.tsx
@@ -77,7 +77,7 @@ const NoLudicaGame = ({ mode }: NoLudicaGameProps) => {
 
           {mode !== "preview" && (
             <div className={styles.responseInput}>
-              <label className={styles.inputLabel}>Tu archivo:</label>
+              <label className={styles.inputLabel}>Archivo adjunto:</label>
               <div className={styles.fileUpload}>
                 <input
                   type="file"

--- a/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameContext.type.ts
+++ b/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameContext.type.ts
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from "react";
 import type { NoLudicaConfig } from "../../../../activity/types/NoLudica.type";
 // import type { GameHook } from "../../../types/Games.type";
 
@@ -20,5 +21,8 @@ export interface NoLudicaGameContextType {
   // Funciones del juego
   setStudentResponse: (data: string) => void;
   setSelectedFile: (data: File | null) => void;
+  handleFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleRemoveFile: () => void;
+  validateNoLudicaSubmission: () => boolean;
   handleFinishNoLudica: () => void;
 }

--- a/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameProvider.tsx
+++ b/src/shared/contexts/gamesContext/noLudicaGameContext/NoLudicaGameProvider.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState, type ChangeEvent, type ReactNode } from "react";
 import { NoLudicaGameContext } from "./NoLudicaGameContext";
 import type { NoLudicaGameContextType } from "./NoLudicaGameContext.type";
 import type { NoLudicaConfig } from "../../../../activity/types/NoLudica.type";
 import { useActivityStudent } from "../../../../student/hooks/useActivityStudentAPI";
 import { useCreateNoLudica } from "../../../../activity/hooks/useCreateNoLudica";
 import { getGameTypeFromActivityName } from "@/shared";
+import { useToaster } from "../../../hooks/useToaster";
 import { GameType } from "../../../types/Games.type";
 import { compressPDF } from "../../../utils/compressPDF";
 import { NO_LUDICA_EMPTY_TEXT_RESPONSE } from "@shared/constants/games.constants";
@@ -22,6 +23,7 @@ export const NoLudicaGameProvider: React.FC<NoLudicaGameProviderProps> = ({
   const { config } = useCreateNoLudica();
   const { currentActivity, registerActivityNoLudicaCompleted } =
     useActivityStudent();
+  const { showToast } = useToaster();
   const [gameStarted, setGameStarted] = useState(false);
   const [studentResponse, setStudentResponse] = useState("");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -58,6 +60,31 @@ export const NoLudicaGameProvider: React.FC<NoLudicaGameProviderProps> = ({
     setGameStarted(false);
   };
 
+  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+    }
+  };
+
+  const handleRemoveFile = () => {
+    setSelectedFile(null);
+  };
+
+  const validateNoLudicaSubmission = (): boolean => {
+    if (!studentResponse.trim() && !selectedFile) {
+      showToast({
+        title: "Entrega vacía",
+        message:
+          "Debes escribir una respuesta o adjuntar un archivo PDF para finalizar el intento.",
+        type: "warning",
+        position: "bottom-right",
+      });
+      return false;
+    }
+    return true;
+  };
+
   const buildFormData = async (): Promise<FormData> => {
     const formData = new FormData();
     if (currentActivity)
@@ -88,6 +115,9 @@ export const NoLudicaGameProvider: React.FC<NoLudicaGameProviderProps> = ({
     gameConfig,
     gameStarted,
     handleFinishNoLudica,
+    handleFileSelect,
+    handleRemoveFile,
+    validateNoLudicaSubmission,
     selectedFile,
     setSelectedFile,
     setStudentResponse,

--- a/src/student/views/studentPlayActivityView/StudentPlayActivityView.tsx
+++ b/src/student/views/studentPlayActivityView/StudentPlayActivityView.tsx
@@ -31,7 +31,8 @@ const StudentPlayActivityView: React.FC<StudentPlayActivityViewProps> = ({
     canNavigate,
     refreshActivitiesOnNavigationAway,
   } = useActivityActions();
-  const { handleFinishNoLudica } = useNoLudicaGame();
+  const { handleFinishNoLudica, validateNoLudicaSubmission } =
+    useNoLudicaGame();
   const navigationMessages = useActivityNavigationMessages(currentActivity);
 
   // Registry Pattern: Obtener el hook del juego apropiado automáticamente
@@ -84,6 +85,8 @@ const StudentPlayActivityView: React.FC<StudentPlayActivityViewProps> = ({
     if (!currentActivity) return;
 
     if (isNoLudica) {
+      if (!validateNoLudicaSubmission()) return;
+
       await finishActivity(
         !!gameManager?.isGameWon,
         gameManager,


### PR DESCRIPTION
# Descripción
Se arregló la no-visualización de posibildiad de entregar un archivo adjunto a la actividad no lúdica

# Explicación
## Estudiante: Archivo adjunto
Por alguna razón, toda la lógica estaba pero se desacopló. Ahora está y funca perfecto:

<img width="1039" height="868" alt="1" src="https://github.com/user-attachments/assets/5673c91b-75c4-4571-afc5-7d2efe4bf408" />

<img width="1039" height="868" alt="2" src="https://github.com/user-attachments/assets/20c37716-35e3-40cc-ae48-7b9b143d1199" />

<img width="1039" height="868" alt="3" src="https://github.com/user-attachments/assets/f40c11b6-27f7-4532-be3e-247139d1c282" />

## Estudiante: Validación faltante
De paso le dije al Claude que le pegue una pispeada al backend por si nos estabamos olvidando alguna validación, y efectivamente, asique también la metí:

<img width="365" height="96" alt="image" src="https://github.com/user-attachments/assets/27549376-f53c-4480-ac42-eec26c42bfa0" />

## Docente: Revisión de actividad
No toqué nada, nomás me fijé si andaba y efectivamente funca

<img width="1166" height="607" alt="image" src="https://github.com/user-attachments/assets/74c41b57-879d-4713-98ed-25e81c540052" />

<img width="1919" height="1033" alt="image" src="https://github.com/user-attachments/assets/65fe2de8-f426-4a4a-96fb-bb76f321d96d" />

Terrible el PDF que se mandó Gemini eh

# Issue relacionada
Closes #318 